### PR TITLE
Add Dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
In response to recent ecosystem attacks on dependencies, we need to add a cooldown period to Dependabot, so Dependabot waits a few days after a version is published before raising a PR. This gives the community time to flag compromised or broken releases.

This does not affect critical security patches. These will still be raised by Dependabot without delay.