### PR TITLE
Cm 966/show rendered block on mouse over

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -148,13 +148,17 @@ test.describe("Content Block Editor", () => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ rendered_blocks: {} }),
+        body: JSON.stringify({
+          rendered_blocks: {
+            [embedCode]: { html: "<p>Rendered block</p>" },
+          },
+        }),
       });
     });
 
     await textarea.fill(embedCode);
     await hoverTextareaAtMark(page);
-    await page.waitForTimeout(previewDelayMs - 50);
+    await page.waitForTimeout(25);
 
     const wrapperBox = await wrapper.boundingBox();
     if (!wrapperBox) {

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -1,10 +1,37 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
 });
 
 test.describe("Content Block Editor", () => {
+  const embedCode =
+    "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab#some_format}}";
+  const previewDelayMs = 200;
+
+  async function hoverTextareaAtMark(page: Page) {
+    const textarea = page.locator("textarea.content-block-highlight__input");
+    const mark = page
+      .locator(".content-block-highlight__highlight")
+      .locator("mark.content-block-highlight__mark");
+
+    const markBox = await mark.boundingBox();
+    const textareaBox = await textarea.boundingBox();
+
+    if (!markBox || !textareaBox) {
+      throw new Error(
+        "Expected embed mark and textarea to have a bounding box",
+      );
+    }
+
+    await textarea.hover({
+      position: {
+        x: markBox.x - textareaBox.x + Math.min(4, markBox.width / 2),
+        y: markBox.y - textareaBox.y + Math.min(4, markBox.height / 2),
+      },
+    });
+  }
+
   test("it makes the highlighter visible", async ({ page }) => {
     const wrapper = page.locator(".content-block-highlight__wrapper");
     const textarea = page.locator("textarea.content-block-highlight__input");
@@ -18,9 +45,6 @@ test.describe("Content Block Editor", () => {
   test("it detects and highlights embed codes", async ({ page }) => {
     const textarea = page.locator("textarea.content-block-highlight__input");
     const highlight = page.locator(".content-block-highlight__highlight");
-
-    const embedCode =
-      "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab}}";
 
     await textarea.fill(embedCode);
 
@@ -77,5 +101,73 @@ test.describe("Content Block Editor", () => {
     const html = await highlight.innerHTML();
     expect(html).toContain("&lt;b&gt;Bold&lt;/b&gt;");
     expect(html).toContain('<mark class="content-block-highlight__mark">');
+  });
+
+  test("it fetches and shows a preview after hovering an embed for 200ms", async ({
+    page,
+  }) => {
+    const textarea = page.locator("textarea.content-block-highlight__input");
+    const preview = page.locator(".content-block-highlight__preview");
+
+    let requestedEmbedCode: string | null = null;
+    await page.route("**/api/blocks/render?*", async (route) => {
+      const requestUrl = new URL(route.request().url());
+      requestedEmbedCode = requestUrl.searchParams.get("embed_codes[]");
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          rendered_blocks: {
+            [embedCode]: { html: "<p>Rendered block</p>" },
+          },
+        }),
+      });
+    });
+
+    await textarea.fill(embedCode);
+    await hoverTextareaAtMark(page);
+
+    await page.waitForTimeout(previewDelayMs - 50);
+    await expect(preview).toBeHidden();
+
+    await expect(preview).toContainText("Rendered block", { timeout: 500 });
+    expect(requestedEmbedCode).toBe(embedCode);
+  });
+
+  test("it does not fetch a preview if hover ends before delay", async ({
+    page,
+  }) => {
+    const textarea = page.locator("textarea.content-block-highlight__input");
+    const preview = page.locator(".content-block-highlight__preview");
+    const wrapper = page.locator(".content-block-highlight__wrapper");
+
+    let requestCount = 0;
+    await page.route("**/api/blocks/render?*", async (route) => {
+      requestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ rendered_blocks: {} }),
+      });
+    });
+
+    await textarea.fill(embedCode);
+    await hoverTextareaAtMark(page);
+    await page.waitForTimeout(previewDelayMs - 50);
+
+    const wrapperBox = await wrapper.boundingBox();
+    if (!wrapperBox) {
+      throw new Error("Expected wrapper to have a bounding box");
+    }
+
+    await page.mouse.move(
+      wrapperBox.x + wrapperBox.width + 20,
+      wrapperBox.y + 10,
+    );
+    await page.waitForTimeout(previewDelayMs + 100);
+
+    expect(requestCount).toBe(0);
+    await expect(preview).toBeHidden();
   });
 });

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -18,6 +18,20 @@
   overflow-wrap: break-word;
 }
 
+.content-block-highlight__mark {
+  cursor: help;
+}
+
+.content-block-highlight__preview {
+  position: absolute;
+  z-index: 2;
+  max-width: 420px;
+  padding: 8px;
+  border: 1px solid #b1b4b6;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgba(11, 12, 12, 0.2);
+}
+
 textarea.content-block-highlight__input {
   position: relative;
   z-index: 1;

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -244,7 +244,7 @@ describe("ContentBlockEditor", () => {
       );
       const secondMark = marks[1] as HTMLElement;
 
-      editor.hoveredEmbedCode = firstEmbed;
+      editor.currentEmbedCodePreview = firstEmbed;
       editor.preview.hidden = false;
       editor.preview.innerHTML = "<p>Old preview</p>";
 
@@ -264,7 +264,7 @@ describe("ContentBlockEditor", () => {
 
       expect(editor.preview.hidden).toBe(true);
       expect(editor.preview.innerHTML).toBe("");
-      expect(editor.hoveredEmbedCode).toBe(secondEmbed);
+      expect(editor.currentEmbedCodePreview).toBe(secondEmbed);
     });
   });
 });
@@ -325,7 +325,7 @@ describe("ContentBlockEditor - Preview Fetching and Rendering", () => {
       mark.className = "content-block-highlight__mark";
       mark.textContent = embedCode;
       editor.highlight.appendChild(mark);
-      editor.hoveredEmbedCode = embedCode;
+      editor.currentEmbedCodePreview = embedCode;
 
       // Mock getBoundingClientRect for positionPreview
       vi.spyOn(mark, "getBoundingClientRect").mockReturnValue({
@@ -421,7 +421,7 @@ describe("ContentBlockEditor - Preview Fetching and Rendering", () => {
       const callPromise = editor.fetchAndRenderPreview(embedCode, mark);
 
       // Change hovered embed code while fetch is pending
-      editor.hoveredEmbedCode = "{{embed:other:456}}";
+      editor.currentEmbedCodePreview = "{{embed:other:456}}";
 
       resolveFetch!({
         ok: true,
@@ -439,7 +439,7 @@ describe("ContentBlockEditor - Preview Fetching and Rendering", () => {
     });
   });
 
-  describe("hidePreview and resetHoverState", () => {
+  describe("hidePreview", () => {
     test("hidePreview clears content and hides element", () => {
       editor.preview.innerHTML = "some content";
       editor.preview.hidden = false;
@@ -449,17 +449,19 @@ describe("ContentBlockEditor - Preview Fetching and Rendering", () => {
       expect(editor.preview.innerHTML).toBe("");
       expect(editor.preview.hidden).toBe(true);
     });
+  });
 
+  describe("resetHoverState", () => {
     test("resetHoverState clears timer and hovered code", () => {
       const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
       editor.hoverTimerId = 123;
-      editor.hoveredEmbedCode = "code";
+      editor.currentEmbedCodePreview = "code";
 
       editor.resetHoverState();
 
       expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
       expect(editor.hoverTimerId).toBeNull();
-      expect(editor.hoveredEmbedCode).toBeNull();
+      expect(editor.currentEmbedCodePreview).toBeNull();
       expect(editor.preview.hidden).toBe(true);
     });
 

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -147,4 +147,340 @@ describe("ContentBlockEditor", () => {
       expect(editors[0]).toBeInstanceOf(ContentBlockEditor);
     });
   });
+
+  describe("embed hover preview", () => {
+    test("it fetches and renders preview HTML after 200ms of hover", async () => {
+      const embedCode =
+        "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab#some_format}}";
+      textarea.value = embedCode;
+      editor.updateHighlight();
+
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          rendered_blocks: {
+            [embedCode]: { html: "<p>Rendered block</p>" },
+          },
+        }),
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockReturnValue([textarea, mark]),
+      });
+
+      editor.wrapper.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 1,
+          clientY: 1,
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      const [calledUrl] = fetchMock.mock.calls[0] as [string];
+      const parsedUrl = new URL(calledUrl, "http://localhost");
+      expect(parsedUrl.pathname).toBe("/api/blocks/render");
+      expect(parsedUrl.searchParams.get("embed_codes[]")).toBe(embedCode);
+      expect(editor.preview.hidden).toBe(false);
+      expect(editor.preview.innerHTML).toContain("Rendered block");
+    });
+
+    test("it cancels preview fetch when hover ends before delay", async () => {
+      textarea.value =
+        "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab}}";
+      editor.updateHighlight();
+
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "<p>Rendered block</p>",
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockReturnValue([textarea, mark]),
+      });
+
+      editor.wrapper.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 1,
+          clientY: 1,
+        }),
+      );
+
+      editor.wrapper.dispatchEvent(
+        new MouseEvent("mouseleave", { bubbles: true }),
+      );
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(editor.preview.hidden).toBe(true);
+    });
+
+    test("it hides stale preview immediately when hovering a different embed", () => {
+      const firstEmbed = "{{embed:contact:123}}";
+      const secondEmbed = "{{embed:contact:456}}";
+
+      textarea.value = `${firstEmbed} ${secondEmbed}`;
+      editor.updateHighlight();
+
+      const marks = editor.highlight.querySelectorAll(
+        ".content-block-highlight__mark",
+      );
+      const secondMark = marks[1] as HTMLElement;
+
+      editor.hoveredEmbedCode = firstEmbed;
+      editor.preview.hidden = false;
+      editor.preview.innerHTML = "<p>Old preview</p>";
+
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockReturnValue([textarea, secondMark]),
+      });
+
+      editor.wrapper.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 1,
+          clientY: 1,
+        }),
+      );
+
+      expect(editor.preview.hidden).toBe(true);
+      expect(editor.preview.innerHTML).toBe("");
+      expect(editor.hoveredEmbedCode).toBe(secondEmbed);
+    });
+  });
+});
+
+describe("ContentBlockEditor - Preview Fetching and Rendering", () => {
+  let textarea: HTMLTextAreaElement;
+  let editor: ContentBlockEditor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="container">
+        <textarea id="my-textarea" data-module="content-block-highlight"></textarea>
+      </div>
+    `;
+    textarea = document.getElementById("my-textarea") as HTMLTextAreaElement;
+    editor = new ContentBlockEditor(textarea);
+  });
+
+  describe("positionPreview", () => {
+    test("it positions the preview relative to the mark and wrapper", () => {
+      const mark = document.createElement("mark");
+      // Mock getBoundingClientRect for mark and wrapper
+      vi.spyOn(mark, "getBoundingClientRect").mockReturnValue({
+        top: 100,
+        bottom: 120,
+        left: 50,
+        right: 150,
+        width: 100,
+        height: 20,
+        x: 50,
+        y: 100,
+      } as DOMRect);
+
+      vi.spyOn(editor.wrapper, "getBoundingClientRect").mockReturnValue({
+        top: 10,
+        bottom: 500,
+        left: 10,
+        right: 610,
+        width: 600,
+        height: 490,
+        x: 10,
+        y: 10,
+      } as DOMRect);
+
+      editor.positionPreview(mark);
+
+      expect(editor.preview.style.left).toBe("40px"); // 50 - 10
+      expect(editor.preview.style.top).toBe("118px"); // 120 - 10 + 8
+    });
+  });
+
+  describe("fetchAndRenderPreview", () => {
+    const embedCode = "{{embed:contact:123}}";
+    let mark: HTMLElement;
+
+    beforeEach(() => {
+      mark = document.createElement("mark");
+      mark.className = "content-block-highlight__mark";
+      mark.textContent = embedCode;
+      editor.highlight.appendChild(mark);
+      editor.hoveredEmbedCode = embedCode;
+
+      // Mock getBoundingClientRect for positionPreview
+      vi.spyOn(mark, "getBoundingClientRect").mockReturnValue({
+        top: 100,
+        bottom: 120,
+        left: 50,
+        right: 150,
+      } as DOMRect);
+      vi.spyOn(editor.wrapper, "getBoundingClientRect").mockReturnValue({
+        top: 10,
+        left: 10,
+      } as DOMRect);
+    });
+
+    test("it renders HTML on successful fetch", async () => {
+      const mockHtml = "<div>Contact Details</div>";
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          rendered_blocks: {
+            [embedCode]: { html: mockHtml },
+          },
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await editor.fetchAndRenderPreview(embedCode, mark);
+
+      const [calledUrl] = fetchMock.mock.calls[0] as [string];
+      const parsedUrl = new URL(calledUrl, "http://localhost");
+      expect(parsedUrl.pathname).toBe("/api/blocks/render");
+      expect(parsedUrl.searchParams.get("embed_codes[]")).toBe(embedCode);
+      expect(editor.preview.innerHTML).toBe(mockHtml);
+      expect(editor.preview.hidden).toBe(false);
+    });
+
+    test("it hides preview if response is not ok", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      editor.preview.hidden = false;
+      editor.preview.innerHTML = "previous content";
+
+      await editor.fetchAndRenderPreview(embedCode, mark);
+
+      expect(editor.preview.hidden).toBe(true);
+      expect(editor.preview.innerHTML).toBe("");
+    });
+
+    test("it hides preview if JSON is missing expected data", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          rendered_blocks: {}, // missing our embedCode
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      editor.preview.hidden = false;
+      await editor.fetchAndRenderPreview(embedCode, mark);
+
+      expect(editor.preview.hidden).toBe(true);
+    });
+
+    test("it hides preview if fetch throws an error", async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error("Network failure"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      editor.preview.hidden = false;
+      await editor.fetchAndRenderPreview(embedCode, mark);
+
+      expect(editor.preview.hidden).toBe(true);
+    });
+
+    test("it does not render if hoveredEmbedCode changed during fetch", async () => {
+      const mockHtml = "<div>Contact Details</div>";
+      type MockFetchResponse = {
+        ok: boolean;
+        json: () => Promise<{
+          rendered_blocks: Record<string, { html: string }>;
+        }>;
+      };
+      let resolveFetch: (value: MockFetchResponse) => void;
+      const fetchPromise = new Promise<MockFetchResponse>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      const fetchMock = vi.fn().mockReturnValue(fetchPromise);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const callPromise = editor.fetchAndRenderPreview(embedCode, mark);
+
+      // Change hovered embed code while fetch is pending
+      editor.hoveredEmbedCode = "{{embed:other:456}}";
+
+      resolveFetch!({
+        ok: true,
+        json: async () => ({
+          rendered_blocks: {
+            [embedCode]: { html: mockHtml },
+          },
+        }),
+      });
+
+      await callPromise;
+
+      expect(editor.preview.innerHTML).toBe("");
+      expect(editor.preview.hidden).toBe(true);
+    });
+  });
+
+  describe("hidePreview and resetHoverState", () => {
+    test("hidePreview clears content and hides element", () => {
+      editor.preview.innerHTML = "some content";
+      editor.preview.hidden = false;
+
+      editor.hidePreview();
+
+      expect(editor.preview.innerHTML).toBe("");
+      expect(editor.preview.hidden).toBe(true);
+    });
+
+    test("resetHoverState clears timer and hovered code", () => {
+      const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+      editor.hoverTimerId = 123;
+      editor.hoveredEmbedCode = "code";
+
+      editor.resetHoverState();
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(123);
+      expect(editor.hoverTimerId).toBeNull();
+      expect(editor.hoveredEmbedCode).toBeNull();
+      expect(editor.preview.hidden).toBe(true);
+    });
+
+    test("handleMouseMove does not reset hover state when no mark is hovered and state is already idle", () => {
+      const resetHoverStateSpy = vi.spyOn(editor, "resetHoverState");
+
+      Object.defineProperty(document, "elementsFromPoint", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockReturnValue([textarea]),
+      });
+
+      editor.wrapper.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 1,
+          clientY: 1,
+        }),
+      );
+
+      expect(resetHoverStateSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -1,18 +1,28 @@
 import "../scss/base.scss";
+import {
+  calculatePreviewPosition,
+  getElementUnderPointer,
+  shouldHidePreview,
+} from "./content-block/hover-preview-utils.ts";
 import embedRegex from "./content-block/regex.ts";
 
-const EMBED_PREVIEW_DELAY_MS = 200;
-const EMBED_RENDER_ENDPOINT = "/api/blocks/render";
-
 export class ContentBlockEditor {
+  readonly embedPreviewDelayMs: number;
+  readonly embedRenderEndpoint: string;
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
   preview: HTMLDivElement;
   hoverTimerId: number | null = null;
-  hoveredEmbedCode: string | null = null;
+  currentEmbedCodePreview: string | null = null;
 
-  constructor(element: Element) {
+  constructor(
+    element: Element,
+    embedPreviewDelayMs: number = 200,
+    embedRenderEndpoint: string = "/api/blocks/render",
+  ) {
+    this.embedPreviewDelayMs = embedPreviewDelayMs;
+    this.embedRenderEndpoint = embedRenderEndpoint;
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();
@@ -25,7 +35,7 @@ export class ContentBlockEditor {
     this.textarea.addEventListener("input", () => this.updateHighlight());
     this.textarea.addEventListener("scroll", () => this.syncScroll());
     this.wrapper.addEventListener("mousemove", (event) =>
-      this.handleMouseMove(event),
+      this.updateHoverState(event),
     );
     this.wrapper.addEventListener("mouseleave", () => this.resetHoverState());
 
@@ -81,52 +91,40 @@ export class ContentBlockEditor {
     return preview;
   }
 
-  getHoveredMark(event: MouseEvent): HTMLElement | null {
-    const elements = document.elementsFromPoint(event.clientX, event.clientY);
+  updateHoverState(event: MouseEvent): void {
+    const elementUnderPointer = getElementUnderPointer(event, this.highlight);
 
-    return (
-      (elements.find(
-        (element) =>
-          element instanceof HTMLElement &&
-          element.classList.contains("content-block-highlight__mark") &&
-          this.highlight.contains(element),
-      ) as HTMLElement | undefined) ?? null
-    );
-  }
-
-  handleMouseMove(event: MouseEvent) {
-    const hoveredMark = this.getHoveredMark(event);
-
-    if (!hoveredMark) {
-      if (this.hasActiveHoverState()) {
+    if (elementUnderPointer === null) {
+      if (shouldHidePreview(this)) {
         this.resetHoverState();
       }
       return;
     }
 
-    const embedCode = hoveredMark.textContent ?? "";
+    const embedCode = elementUnderPointer.textContent ?? "";
 
-    if (!embedCode || this.hoveredEmbedCode === embedCode) {
+    if (this.currentEmbedCodePreview === embedCode) {
       return;
     }
 
-    if (this.hoveredEmbedCode !== null) {
+    if (this.currentEmbedCodePreview !== null) {
       this.hidePreview();
     }
 
     this.clearHoverTimer();
-    this.hoveredEmbedCode = embedCode;
+    this.currentEmbedCodePreview = embedCode;
 
     this.hoverTimerId = window.setTimeout(async () => {
+      this.hoverTimerId = null;
       if (
-        this.hoveredEmbedCode !== embedCode ||
-        !this.highlight.contains(hoveredMark)
+        this.currentEmbedCodePreview !== embedCode ||
+        !this.highlight.contains(elementUnderPointer)
       ) {
         return;
       }
 
-      await this.fetchAndRenderPreview(embedCode, hoveredMark);
-    }, EMBED_PREVIEW_DELAY_MS);
+      await this.fetchAndRenderPreview(embedCode, elementUnderPointer);
+    }, this.embedPreviewDelayMs);
   }
 
   clearHoverTimer() {
@@ -137,33 +135,21 @@ export class ContentBlockEditor {
   }
 
   hidePreview() {
-    if (this.preview.hidden && this.preview.innerHTML === "") {
-      return;
-    }
-
     this.preview.hidden = true;
+    this.preview.setAttribute("aria-hidden", "true");
     this.preview.innerHTML = "";
-  }
-
-  hasActiveHoverState() {
-    return (
-      this.hoverTimerId !== null ||
-      this.hoveredEmbedCode !== null ||
-      !this.preview.hidden ||
-      this.preview.innerHTML !== ""
-    );
   }
 
   resetHoverState() {
     this.clearHoverTimer();
-    this.hoveredEmbedCode = null;
+    this.currentEmbedCodePreview = null;
     this.hidePreview();
   }
 
   async fetchAndRenderPreview(embedCode: string, markElement: HTMLElement) {
     try {
       const query = new URLSearchParams({ "embed_codes[]": embedCode });
-      const url = `${EMBED_RENDER_ENDPOINT}?${query.toString()}`;
+      const url = `${this.embedRenderEndpoint}?${query.toString()}`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -171,12 +157,10 @@ export class ContentBlockEditor {
         return;
       }
 
-      const json = await response.json();
-
-      if (this.hoveredEmbedCode !== embedCode) {
+      if (this.currentEmbedCodePreview !== embedCode) {
         return;
       }
-
+      const json = await response.json();
       const html = json.rendered_blocks?.[embedCode]?.html;
 
       if (!html) {
@@ -187,17 +171,16 @@ export class ContentBlockEditor {
       this.preview.innerHTML = html;
       this.positionPreview(markElement);
       this.preview.hidden = false;
+      this.preview.setAttribute("aria-hidden", "false");
     } catch {
       this.hidePreview();
     }
   }
 
-  positionPreview(markElement: HTMLElement) {
-    const markRect = markElement.getBoundingClientRect();
-    const wrapperRect = this.wrapper.getBoundingClientRect();
-
-    this.preview.style.left = `${markRect.left - wrapperRect.left}px`;
-    this.preview.style.top = `${markRect.bottom - wrapperRect.top + 8}px`;
+  positionPreview(markElement: HTMLElement): void {
+    const position = calculatePreviewPosition(markElement, this.wrapper);
+    this.preview.style.left = position.left;
+    this.preview.style.top = position.top;
   }
 
   updateHighlight() {

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -1,15 +1,22 @@
 import "../scss/base.scss";
 import embedRegex from "./content-block/regex.ts";
 
+const EMBED_PREVIEW_DELAY_MS = 200;
+const EMBED_RENDER_ENDPOINT = "/api/blocks/render";
+
 export class ContentBlockEditor {
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
+  preview: HTMLDivElement;
+  hoverTimerId: number | null = null;
+  hoveredEmbedCode: string | null = null;
 
   constructor(element: Element) {
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();
+    this.preview = this.createPreview();
 
     this.textarea.classList.add("content-block-highlight__input");
 
@@ -17,6 +24,10 @@ export class ContentBlockEditor {
 
     this.textarea.addEventListener("input", () => this.updateHighlight());
     this.textarea.addEventListener("scroll", () => this.syncScroll());
+    this.wrapper.addEventListener("mousemove", (event) =>
+      this.handleMouseMove(event),
+    );
+    this.wrapper.addEventListener("mouseleave", () => this.resetHoverState());
 
     // checks for changes to the dimensions of the textarea, and syncs the scroll position of the highlight accordingly
     // see docs: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
@@ -59,7 +70,139 @@ export class ContentBlockEditor {
     return highlight;
   }
 
+  createPreview(): HTMLDivElement {
+    const preview = document.createElement("div");
+    preview.className = "content-block-highlight__preview";
+    preview.hidden = true;
+    preview.setAttribute("aria-hidden", "true");
+
+    this.wrapper.appendChild(preview);
+
+    return preview;
+  }
+
+  getHoveredMark(event: MouseEvent): HTMLElement | null {
+    const elements = document.elementsFromPoint(event.clientX, event.clientY);
+
+    return (
+      (elements.find(
+        (element) =>
+          element instanceof HTMLElement &&
+          element.classList.contains("content-block-highlight__mark") &&
+          this.highlight.contains(element),
+      ) as HTMLElement | undefined) ?? null
+    );
+  }
+
+  handleMouseMove(event: MouseEvent) {
+    const hoveredMark = this.getHoveredMark(event);
+
+    if (!hoveredMark) {
+      if (this.hasActiveHoverState()) {
+        this.resetHoverState();
+      }
+      return;
+    }
+
+    const embedCode = hoveredMark.textContent ?? "";
+
+    if (!embedCode || this.hoveredEmbedCode === embedCode) {
+      return;
+    }
+
+    if (this.hoveredEmbedCode !== null) {
+      this.hidePreview();
+    }
+
+    this.clearHoverTimer();
+    this.hoveredEmbedCode = embedCode;
+
+    this.hoverTimerId = window.setTimeout(async () => {
+      if (
+        this.hoveredEmbedCode !== embedCode ||
+        !this.highlight.contains(hoveredMark)
+      ) {
+        return;
+      }
+
+      await this.fetchAndRenderPreview(embedCode, hoveredMark);
+    }, EMBED_PREVIEW_DELAY_MS);
+  }
+
+  clearHoverTimer() {
+    if (this.hoverTimerId !== null) {
+      window.clearTimeout(this.hoverTimerId);
+      this.hoverTimerId = null;
+    }
+  }
+
+  hidePreview() {
+    if (this.preview.hidden && this.preview.innerHTML === "") {
+      return;
+    }
+
+    this.preview.hidden = true;
+    this.preview.innerHTML = "";
+  }
+
+  hasActiveHoverState() {
+    return (
+      this.hoverTimerId !== null ||
+      this.hoveredEmbedCode !== null ||
+      !this.preview.hidden ||
+      this.preview.innerHTML !== ""
+    );
+  }
+
+  resetHoverState() {
+    this.clearHoverTimer();
+    this.hoveredEmbedCode = null;
+    this.hidePreview();
+  }
+
+  async fetchAndRenderPreview(embedCode: string, markElement: HTMLElement) {
+    try {
+      const query = new URLSearchParams({ "embed_codes[]": embedCode });
+      const url = `${EMBED_RENDER_ENDPOINT}?${query.toString()}`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        this.hidePreview();
+        return;
+      }
+
+      const json = await response.json();
+
+      if (this.hoveredEmbedCode !== embedCode) {
+        return;
+      }
+
+      const html = json.rendered_blocks?.[embedCode]?.html;
+
+      if (!html) {
+        this.hidePreview();
+        return;
+      }
+
+      this.preview.innerHTML = html;
+      this.positionPreview(markElement);
+      this.preview.hidden = false;
+    } catch {
+      this.hidePreview();
+    }
+  }
+
+  positionPreview(markElement: HTMLElement) {
+    const markRect = markElement.getBoundingClientRect();
+    const wrapperRect = this.wrapper.getBoundingClientRect();
+
+    this.preview.style.left = `${markRect.left - wrapperRect.left}px`;
+    this.preview.style.top = `${markRect.bottom - wrapperRect.top + 8}px`;
+  }
+
   updateHighlight() {
+    this.resetHoverState();
+
     let text = this.textarea.value;
 
     if (text[text.length - 1] === "\n") {

--- a/src/content-block/hover-preview-utils.spec.ts
+++ b/src/content-block/hover-preview-utils.spec.ts
@@ -1,0 +1,281 @@
+import { expect, test, describe, beforeEach, vi } from "vitest";
+import {
+  getElementUnderPointer,
+  shouldHidePreview,
+  calculatePreviewPosition,
+} from "./hover-preview-utils.ts";
+import { ContentBlockEditor } from "../content-block-editor.ts";
+
+describe("getElementUnderPointer", () => {
+  let highlight: HTMLElement;
+  let mark: HTMLElement;
+
+  beforeEach(() => {
+    highlight = document.createElement("div");
+    highlight.className = "content-block-highlight__highlight";
+
+    mark = document.createElement("mark");
+    mark.className = "content-block-highlight__mark";
+    mark.textContent = "{{embed:contact:123}}";
+    highlight.appendChild(mark);
+  });
+
+  test("returns the mark element when it is under the pointer and within highlight", () => {
+    const event = new MouseEvent("mousemove", {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue([mark, highlight]),
+    });
+
+    const result = getElementUnderPointer(event, highlight);
+
+    expect(result).toBe(mark);
+  });
+
+  test("returns null when no mark is under the pointer", () => {
+    const event = new MouseEvent("mousemove", {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    const div = document.createElement("div");
+
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue([div]),
+    });
+
+    const result = getElementUnderPointer(event, highlight);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when element under pointer is not an HTMLElement", () => {
+    const event = new MouseEvent("mousemove", {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    const textNode = document.createTextNode("text");
+
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue([textNode]),
+    });
+
+    const result = getElementUnderPointer(event, highlight);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when mark is not within the highlight element", () => {
+    const event = new MouseEvent("mousemove", {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    const externalMark = document.createElement("mark");
+    externalMark.className = "content-block-highlight__mark";
+
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue([externalMark]),
+    });
+
+    const result = getElementUnderPointer(event, highlight);
+
+    expect(result).toBeNull();
+  });
+
+  test("finds the mark when multiple elements are at point", () => {
+    const event = new MouseEvent("mousemove", {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    const div = document.createElement("div");
+    const otherMark = document.createElement("mark");
+
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue([div, otherMark, mark]),
+    });
+
+    const result = getElementUnderPointer(event, highlight);
+
+    expect(result).toBe(mark);
+  });
+});
+
+describe("shouldHidePreview", () => {
+  let textarea: HTMLTextAreaElement;
+  let editor: ContentBlockEditor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <textarea id="my-textarea"></textarea>
+    `;
+    textarea = document.getElementById("my-textarea") as HTMLTextAreaElement;
+    editor = new ContentBlockEditor(textarea);
+  });
+
+  test("returns true when there is a pending timer", () => {
+    editor.hoverTimerId = 123;
+    editor.currentEmbedCodePreview = null;
+    editor.preview.hidden = true;
+    editor.preview.innerHTML = "";
+
+    expect(shouldHidePreview(editor)).toBe(true);
+  });
+
+  test("returns true when there is a tracked embed code", () => {
+    editor.hoverTimerId = null;
+    editor.currentEmbedCodePreview = "{{embed:contact:123}}";
+    editor.preview.hidden = true;
+    editor.preview.innerHTML = "";
+
+    expect(shouldHidePreview(editor)).toBe(true);
+  });
+
+  test("returns true when preview is visible", () => {
+    editor.hoverTimerId = null;
+    editor.currentEmbedCodePreview = null;
+    editor.preview.hidden = false;
+    editor.preview.innerHTML = "";
+
+    expect(shouldHidePreview(editor)).toBe(true);
+  });
+
+  test("returns true when preview has content", () => {
+    editor.hoverTimerId = null;
+    editor.currentEmbedCodePreview = null;
+    editor.preview.hidden = true;
+    editor.preview.innerHTML = "<p>Content</p>";
+
+    expect(shouldHidePreview(editor)).toBe(true);
+  });
+
+  test("returns false when all conditions are false", () => {
+    editor.hoverTimerId = null;
+    editor.currentEmbedCodePreview = null;
+    editor.preview.hidden = true;
+    editor.preview.innerHTML = "";
+
+    expect(shouldHidePreview(editor)).toBe(false);
+  });
+
+  test("returns true when multiple conditions are true", () => {
+    editor.hoverTimerId = 123;
+    editor.currentEmbedCodePreview = "{{embed:contact:123}}";
+    editor.preview.hidden = false;
+    editor.preview.innerHTML = "<p>Content</p>";
+
+    expect(shouldHidePreview(editor)).toBe(true);
+  });
+});
+
+describe("calculatePreviewPosition", () => {
+  let markElement: HTMLElement;
+  let wrapperElement: HTMLElement;
+
+  beforeEach(() => {
+    markElement = document.createElement("mark");
+    wrapperElement = document.createElement("div");
+  });
+
+  test("calculates left position as mark left minus wrapper left", () => {
+    vi.spyOn(markElement, "getBoundingClientRect").mockReturnValue({
+      left: 150,
+      bottom: 120,
+      width: 100,
+      height: 20,
+      top: 100,
+      right: 250,
+      x: 150,
+      y: 100,
+    } as DOMRect);
+
+    vi.spyOn(wrapperElement, "getBoundingClientRect").mockReturnValue({
+      left: 50,
+      top: 10,
+      width: 600,
+      height: 490,
+      bottom: 500,
+      right: 650,
+      x: 50,
+      y: 10,
+    } as DOMRect);
+
+    const position = calculatePreviewPosition(markElement, wrapperElement);
+
+    expect(position.left).toBe("100px"); // 150 - 50
+  });
+
+  test("calculates top position as mark bottom minus wrapper top plus 8px", () => {
+    vi.spyOn(markElement, "getBoundingClientRect").mockReturnValue({
+      left: 50,
+      bottom: 120,
+      width: 100,
+      height: 20,
+      top: 100,
+      right: 150,
+      x: 50,
+      y: 100,
+    } as DOMRect);
+
+    vi.spyOn(wrapperElement, "getBoundingClientRect").mockReturnValue({
+      left: 10,
+      top: 10,
+      width: 600,
+      height: 490,
+      bottom: 500,
+      right: 610,
+      x: 10,
+      y: 10,
+    } as DOMRect);
+
+    const position = calculatePreviewPosition(markElement, wrapperElement);
+
+    expect(position.top).toBe("118px"); // 120 - 10 + 8
+  });
+
+  test("returns both left and top as pixel strings", () => {
+    vi.spyOn(markElement, "getBoundingClientRect").mockReturnValue({
+      left: 100,
+      bottom: 100,
+      width: 50,
+      height: 20,
+      top: 80,
+      right: 150,
+      x: 100,
+      y: 80,
+    } as DOMRect);
+
+    vi.spyOn(wrapperElement, "getBoundingClientRect").mockReturnValue({
+      left: 20,
+      top: 20,
+      width: 500,
+      height: 400,
+      bottom: 420,
+      right: 520,
+      x: 20,
+      y: 20,
+    } as DOMRect);
+
+    const position = calculatePreviewPosition(markElement, wrapperElement);
+
+    expect(position.left).toBe("80px");
+    expect(position.top).toBe("88px");
+    expect(typeof position.left).toBe("string");
+    expect(typeof position.top).toBe("string");
+  });
+});

--- a/src/content-block/hover-preview-utils.ts
+++ b/src/content-block/hover-preview-utils.ts
@@ -1,0 +1,62 @@
+import type { ContentBlockEditor } from "../content-block-editor.ts";
+
+export type HoveredEmbedMatch = {
+  embedCode: string;
+  hoveredMark: HTMLElement;
+};
+
+export function getElementUnderPointer(
+  event: MouseEvent,
+  highlight: HTMLElement,
+): HTMLElement | null {
+  const elementsAtPoint = document.elementsFromPoint(
+    event.clientX,
+    event.clientY,
+  );
+
+  const elementUnderPointer = elementsAtPoint.find((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+
+    const isEmbedMark = element.classList.contains(
+      "content-block-highlight__mark",
+    );
+    const isWithinHighlight = highlight.contains(element);
+
+    return isEmbedMark && isWithinHighlight;
+  });
+
+  if (!(elementUnderPointer instanceof HTMLElement)) {
+    return null;
+  }
+
+  return elementUnderPointer;
+}
+
+export function shouldHidePreview(cbd: ContentBlockEditor): boolean {
+  const hasPendingTimer = cbd.hoverTimerId !== null;
+  const hasTrackedEmbedCode = cbd.currentEmbedCodePreview !== null;
+  const hasVisiblePreview = cbd.preview.hidden === false;
+  const hasPreviewContent = cbd.preview.innerHTML !== "";
+
+  return (
+    hasPendingTimer ||
+    hasTrackedEmbedCode ||
+    hasVisiblePreview ||
+    hasPreviewContent
+  );
+}
+
+export function calculatePreviewPosition(
+  markElement: HTMLElement,
+  wrapperElement: HTMLElement,
+): { left: string; top: string } {
+  const markRect = markElement.getBoundingClientRect();
+  const wrapperRect = wrapperElement.getBoundingClientRect();
+
+  const left = `${markRect.left - wrapperRect.left}px`;
+  const top = `${markRect.bottom - wrapperRect.top + 8}px`;
+
+  return { left, top };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,14 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
 
+const cbmEndpoint =
+  process.env.CBM_ENDPOINT || "http://content-block-manager.dev.gov.uk";
+
 export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://content-block-manager.dev.gov.uk",
+        target: cbmEndpoint,
         changeOrigin: true,
         secure: false,
       },

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,15 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 
 export default defineConfig({
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://content-block-manager.dev.gov.uk",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   build: {
     lib: {
       entry: resolve(__dirname, "src/content-block-editor.ts"),


### PR DESCRIPTION
*NB* - This draft uses a vite request proxy to bypass a CORS error. IT IS NOR READY FOR LIVE

We need to decide:

1. how the constants are the top of src/content-block-editor.ts are set/passed 
2. how we avoid the CORS error when we are not deving