### PR TITLE
Cm 966/show rendered block on mouse over

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ Then initialise the Javascript:
 ```javascript
 import { ContentBlockEditor } from "content-block-editor";
 
-ContentBlockEditor.initAll();
+ContentBlockEditor.initAll({
+  baseUrl: "http://content-block-manager.dev.gov.uk",
+});
+// or
+ContentBlockEditor.initAll({
+  baseUrl: "http://content-block-manager.dev.gov.uk",
+  embedPreviewDelayMs: 500,
+});
 ```
 
 ## Demo

--- a/index.html
+++ b/index.html
@@ -120,7 +120,9 @@
     </script>
     <script type="module">
       import { ContentBlockEditor } from "/src/content-block-editor.ts";
-      new ContentBlockEditor(document.querySelector(".my-textarea"));
+      new ContentBlockEditor(document.querySelector(".my-textarea"), {
+        baseUrl: "http://localhost:5173/",
+      });
     </script>
     <script type="application/json" id="content-blocks">
       [

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -32,6 +32,7 @@ textarea.content-block-highlight__input {
 .content-block-highlight__preview {
   position: absolute;
   z-index: 2;
+  pointer-events: none;
   max-width: 28rem;
   padding: 0.75rem;
   border: 1px solid $govuk-border-colour;

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -28,3 +28,13 @@ textarea.content-block-highlight__input {
 
   resize: none;
 }
+
+.content-block-highlight__preview {
+  position: absolute;
+  z-index: 2;
+  max-width: 28rem;
+  padding: 0.75rem;
+  border: 1px solid $govuk-border-colour;
+  background: $govuk-body-background-colour;
+  box-shadow: 0 2px 8px rgb(11 12 12 / 20%);
+}

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test, describe, beforeEach, vi } from "vitest";
 import { ContentBlockEditor } from "./content-block-editor.ts";
 
-describe("ContentBlockEditor", () => {
+describe("ContentBlockPicker", () => {
   let textarea: HTMLTextAreaElement;
   let editor: ContentBlockEditor;
+
+  const testDelayMs = 314;
+  const testEndpoint = "/api/foo";
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -54,6 +57,16 @@ describe("ContentBlockEditor", () => {
     });
   });
 
+  describe("createHoverPreview", () => {
+    test("it creates an element attached to the wrapper", () => {
+      const preview = editor.preview;
+
+      expect(preview.className).toContain("content-block-highlight__preview");
+      expect(preview.getAttribute("aria-hidden")).toBe("true");
+      expect(editor.wrapper.contains(preview)).toBe(true);
+    });
+  });
+
   describe("updateHighlight", () => {
     test("it escapes HTML and wraps embed codes", () => {
       editor.textarea = textarea;
@@ -80,7 +93,11 @@ describe("ContentBlockEditor", () => {
 
   describe("constructor & events", () => {
     test("the constructor initializes everything correctly", () => {
-      const editorInstance = new ContentBlockEditor(textarea);
+      const editorInstance = new ContentBlockEditor(
+        textarea,
+        testDelayMs,
+        testEndpoint,
+      );
 
       expect(editorInstance.textarea).toBe(textarea);
       expect(
@@ -96,6 +113,15 @@ describe("ContentBlockEditor", () => {
       expect(
         textarea.classList.contains("content-block-highlight__input"),
       ).toBe(true);
+
+      expect(
+        editorInstance.preview.classList.contains(
+          "content-block-highlight__preview",
+        ),
+      ).toBe(true);
+      expect(editorInstance.preview.getAttribute("aria-hidden")).toBe("true");
+      expect(editorInstance.embedPreviewDelayMs).toBe(testDelayMs);
+      expect(editorInstance.embedRenderEndpoint).toBe(testEndpoint);
     });
 
     test("it updates the highlight on input", () => {

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -72,8 +72,8 @@ describe("ContentBlockPicker", () => {
     test("it creates an element attached to the wrapper", () => {
       const preview = editor.preview;
 
+      expect(preview).toBeInstanceOf(HTMLIFrameElement);
       expect(preview.className).toContain("content-block-highlight__preview");
-      expect(preview.getAttribute("aria-hidden")).toBe("true");
       expect(editor.wrapper.contains(preview)).toBe(true);
     });
   });
@@ -121,7 +121,7 @@ describe("ContentBlockPicker", () => {
 
       await vi.waitFor(() => {
         expect(editor.preview.hidden).toBe(false);
-        expect(editor.preview.innerHTML).toBe("<p>Rendered</p>");
+        expect(editor.preview.srcdoc).toContain("<p>Rendered</p>");
       });
     });
 
@@ -185,8 +185,8 @@ describe("ContentBlockPicker", () => {
       textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
       await vi.advanceTimersByTimeAsync(embedPreviewDelayMs);
 
-      expect(editor.preview.hidden).toBe(true);
-      expect(editor.preview.innerHTML).toBe("");
+      expect(editor.preview.srcdoc).toBe("");
+      expect(editor.preview.getAttribute("aria-hidden")).not.toBe("false");
     });
   });
 
@@ -212,12 +212,7 @@ describe("ContentBlockPicker", () => {
         textarea.classList.contains("content-block-highlight__input"),
       ).toBe(true);
 
-      expect(
-        editorInstance.preview.classList.contains(
-          "content-block-highlight__preview",
-        ),
-      ).toBe(true);
-      expect(editorInstance.preview.getAttribute("aria-hidden")).toBe("true");
+      expect(editorInstance.preview).toBeInstanceOf(HTMLIFrameElement);
       expect(editorInstance.embedPreviewDelayMs).toBe(embedPreviewDelayMs);
     });
 

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -5,8 +5,19 @@ describe("ContentBlockPicker", () => {
   let textarea: HTMLTextAreaElement;
   let editor: ContentBlockEditor;
 
-  const testDelayMs = 314;
-  const testEndpoint = "/api/foo";
+  const embedPreviewDelayMs = 314;
+  const baseUrl = "http://not-used.test";
+
+  function mockSuccessFetch() {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue("<p>Rendered</p>"),
+    } as unknown as Response);
+
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -15,7 +26,7 @@ describe("ContentBlockPicker", () => {
       </div>
     `;
     textarea = document.getElementById("my-textarea") as HTMLTextAreaElement;
-    editor = new ContentBlockEditor(textarea);
+    editor = new ContentBlockEditor(textarea, { baseUrl, embedPreviewDelayMs });
   });
 
   describe("initializeModule", () => {
@@ -93,11 +104,10 @@ describe("ContentBlockPicker", () => {
 
   describe("constructor & events", () => {
     test("the constructor initializes everything correctly", () => {
-      const editorInstance = new ContentBlockEditor(
-        textarea,
-        testDelayMs,
-        testEndpoint,
-      );
+      const editorInstance = new ContentBlockEditor(textarea, {
+        baseUrl,
+        embedPreviewDelayMs,
+      });
 
       expect(editorInstance.textarea).toBe(textarea);
       expect(
@@ -120,12 +130,11 @@ describe("ContentBlockPicker", () => {
         ),
       ).toBe(true);
       expect(editorInstance.preview.getAttribute("aria-hidden")).toBe("true");
-      expect(editorInstance.embedPreviewDelayMs).toBe(testDelayMs);
-      expect(editorInstance.embedRenderEndpoint).toBe(testEndpoint);
+      expect(editorInstance.embedPreviewDelayMs).toBe(embedPreviewDelayMs);
     });
 
     test("it updates the highlight on input", () => {
-      new ContentBlockEditor(textarea);
+      new ContentBlockEditor(textarea, { baseUrl });
       textarea.value = "{{embed:contact:123}}";
       textarea.dispatchEvent(new Event("input"));
 
@@ -136,7 +145,7 @@ describe("ContentBlockPicker", () => {
     });
 
     test("it syncs scroll positions", () => {
-      const editorInstance = new ContentBlockEditor(textarea);
+      const editorInstance = new ContentBlockEditor(textarea, { baseUrl });
       textarea.scrollTop = 50;
       textarea.scrollLeft = 20;
       textarea.dispatchEvent(new Event("scroll"));
@@ -147,7 +156,7 @@ describe("ContentBlockPicker", () => {
 
     test("it initializes ResizeObserver to sync scroll on resize", () => {
       const observeSpy = vi.spyOn(ResizeObserver.prototype, "observe");
-      new ContentBlockEditor(textarea);
+      new ContentBlockEditor(textarea, { baseUrl });
 
       expect(observeSpy).toHaveBeenCalledWith(textarea);
     });
@@ -159,7 +168,7 @@ describe("ContentBlockPicker", () => {
         <textarea data-module="content-block-highlight"></textarea>
         <textarea data-module="content-block-highlight"></textarea>
       `;
-      const editors = ContentBlockEditor.initAll();
+      const editors = ContentBlockEditor.initAll({ baseUrl });
       expect(editors.length).toBe(2);
       expect(editors[0]).toBeInstanceOf(ContentBlockEditor);
     });
@@ -168,9 +177,28 @@ describe("ContentBlockPicker", () => {
       document.body.innerHTML = `
         <textarea data-module="content-block-highlight some-other-module"></textarea>
       `;
-      const editors = ContentBlockEditor.initAll();
+      const editors = ContentBlockEditor.initAll({ baseUrl });
       expect(editors.length).toBe(1);
       expect(editors[0]).toBeInstanceOf(ContentBlockEditor);
+    });
+
+    test("it passes baseUrl from options to API requests", async () => {
+      const fetchMock = mockSuccessFetch();
+      document.body.innerHTML = `
+        <textarea data-module="content-block-highlight">{{embed:contact:123}}</textarea>
+      `;
+
+      const [editorInstance] = ContentBlockEditor.initAll({
+        baseUrl: "https://publisher.test",
+      });
+
+      editorInstance.textarea.dispatchEvent(new Event("input"));
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "https://publisher.test/api/blocks/%7B%7Bembed%3Acontact%3A123%7D%7D/render",
+        );
+      });
     });
   });
 });

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -102,6 +102,94 @@ describe("ContentBlockPicker", () => {
     });
   });
 
+  describe("hover preview", () => {
+    test("it renders cached HTML on mark mouseover", async () => {
+      const fetchMock = mockSuccessFetch();
+
+      textarea.value = "{{embed:contact:123}}";
+      textarea.dispatchEvent(new Event("input"));
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+
+      vi.spyOn(editor, "getMarkUnderCursor").mockReturnValue(mark);
+      textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(embedPreviewDelayMs);
+
+      await vi.waitFor(() => {
+        expect(editor.preview.hidden).toBe(false);
+        expect(editor.preview.innerHTML).toBe("<p>Rendered</p>");
+      });
+    });
+
+    test("it hides the preview on mark mouseout", async () => {
+      const fetchMock = mockSuccessFetch();
+
+      textarea.value = "{{embed:contact:123}}";
+      textarea.dispatchEvent(new Event("input"));
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+
+      vi.spyOn(editor, "getMarkUnderCursor").mockReturnValue(mark);
+      textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(embedPreviewDelayMs);
+      await vi.waitFor(() => expect(editor.preview.hidden).toBe(false));
+
+      textarea.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+
+      expect(editor.preview.hidden).toBe(true);
+      expect(editor.preview.innerHTML).toBe("");
+    });
+
+    test("it hides the preview when the cursor moves off the mark", async () => {
+      const fetchMock = mockSuccessFetch();
+
+      textarea.value = "{{embed:contact:123}}";
+      textarea.dispatchEvent(new Event("input"));
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+
+      const getMarkSpy = vi
+        .spyOn(editor, "getMarkUnderCursor")
+        .mockReturnValue(mark);
+      textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(embedPreviewDelayMs);
+      await vi.waitFor(() => expect(editor.preview.hidden).toBe(false));
+
+      getMarkSpy.mockReturnValue(null);
+      textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+      expect(editor.preview.hidden).toBe(true);
+      expect(editor.preview.innerHTML).toBe("");
+    });
+
+    test("it does not show a preview when embed is not cached", async () => {
+      editor.highlight.innerHTML =
+        '<mark class="content-block-highlight__mark">{{embed:contact:123}}</mark>';
+      const mark = editor.highlight.querySelector(
+        ".content-block-highlight__mark",
+      ) as HTMLElement;
+
+      vi.spyOn(editor, "getMarkUnderCursor").mockReturnValue(mark);
+      textarea.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(embedPreviewDelayMs);
+
+      expect(editor.preview.hidden).toBe(true);
+      expect(editor.preview.innerHTML).toBe("");
+    });
+  });
+
   describe("constructor & events", () => {
     test("the constructor initializes everything correctly", () => {
       const editorInstance = new ContentBlockEditor(textarea, {

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -1,5 +1,6 @@
 import "../scss/base.scss";
 import embedRegex from "./content-block/regex.ts";
+import { createHoverPreviewElement } from "./content-block/hover-preview-utils.ts";
 
 export class ContentBlockEditor {
   readonly embedPreviewDelayMs: number;
@@ -7,6 +8,7 @@ export class ContentBlockEditor {
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
+  preview: HTMLDivElement;
 
   constructor(
     element: Element,
@@ -18,6 +20,9 @@ export class ContentBlockEditor {
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();
+
+    this.preview = createHoverPreviewElement();
+    this.wrapper.appendChild(this.preview);
 
     this.textarea.classList.add("content-block-highlight__input");
 

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -2,11 +2,19 @@ import "../scss/base.scss";
 import embedRegex from "./content-block/regex.ts";
 
 export class ContentBlockEditor {
+  readonly embedPreviewDelayMs: number;
+  readonly embedRenderEndpoint: string;
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
 
-  constructor(element: Element) {
+  constructor(
+    element: Element,
+    embedPreviewDelayMs: number = 200,
+    embedRenderEndpoint: string = "/api/blocks/render",
+  ) {
+    this.embedPreviewDelayMs = embedPreviewDelayMs;
+    this.embedRenderEndpoint = embedRenderEndpoint;
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -15,6 +15,9 @@ export class ContentBlockEditor {
   highlight: HTMLDivElement;
   preview: HTMLDivElement;
   apiClient: APIClient;
+  hoverPreviewTimeoutId?: number;
+  activeHoverEmbedCode: string | null = null;
+  currentMarkUnderCursor: HTMLElement | null = null;
 
   constructor(element: Element, options: ContentBlockEditorOptions) {
     this.embedPreviewDelayMs = options?.embedPreviewDelayMs ?? 200;
@@ -34,6 +37,13 @@ export class ContentBlockEditor {
 
     this.textarea.addEventListener("input", () => this.updateHighlight());
     this.textarea.addEventListener("scroll", () => this.syncScroll());
+    this.textarea.addEventListener(
+      "mousemove",
+      (event) => void this.onTextareaMouseMove(event),
+    );
+    this.textarea.addEventListener("mouseleave", () =>
+      this.onTextareaMouseLeave(),
+    );
 
     // checks for changes to the dimensions of the textarea, and syncs the scroll position of the highlight accordingly
     // see docs: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
@@ -96,9 +106,103 @@ export class ContentBlockEditor {
     );
 
     this.highlight.innerHTML = text;
+
     const allEmbedCodes = text.matchAll(embedRegex);
     for (const embedCode of allEmbedCodes) {
-      void this.apiClient.get(embedCode[0]).catch((e) => console.error(e));
+      void this.apiClient
+        .fetchPreview(embedCode[0])
+        .catch((e) => console.error(e));
+    }
+  }
+
+  async onTextareaMouseMove(event: MouseEvent) {
+    const mark = this.getMarkUnderCursor(event);
+    if (mark === this.currentMarkUnderCursor) return;
+
+    const previousMark = this.currentMarkUnderCursor;
+    this.currentMarkUnderCursor = mark;
+
+    if (previousMark) {
+      this.onMarkLeave();
+    }
+    if (mark) {
+      await this.onMarkEnter(mark);
+    }
+  }
+
+  onTextareaMouseLeave() {
+    this.currentMarkUnderCursor = null;
+    this.onMarkLeave();
+  }
+
+  getMarkUnderCursor(event: MouseEvent): HTMLElement | null {
+    this.textarea.style.pointerEvents = "none";
+    const el = document.elementFromPoint(event.clientX, event.clientY);
+    this.textarea.style.pointerEvents = "";
+    if (!(el instanceof Element)) return null;
+    const mark = el.closest(".content-block-highlight__mark");
+    return mark instanceof HTMLElement ? mark : null;
+  }
+
+  async onMarkEnter(mark: HTMLElement) {
+    const embedCode = mark.textContent?.trim();
+    if (!embedCode) return;
+
+    const cachedPreviewPromise = this.apiClient.get(embedCode);
+    if (!cachedPreviewPromise) return;
+
+    this.activeHoverEmbedCode = embedCode;
+    this.clearHoverTimer();
+
+    this.hoverPreviewTimeoutId = window.setTimeout(() => {
+      void this.renderHoverPreview(mark, embedCode, cachedPreviewPromise);
+    }, this.embedPreviewDelayMs);
+  }
+
+  onMarkLeave() {
+    this.activeHoverEmbedCode = null;
+    this.clearHoverTimer();
+    this.hideHoverPreview();
+  }
+
+  private async renderHoverPreview(
+    mark: HTMLElement,
+    embedCode: string,
+    cachedPreviewPromise: NonNullable<ReturnType<APIClient["get"]>>,
+  ) {
+    try {
+      const preview = await cachedPreviewPromise;
+      if (this.activeHoverEmbedCode !== embedCode) return;
+
+      this.preview.innerHTML = preview.html;
+      this.positionHoverPreview(mark);
+      this.preview.hidden = false;
+    } catch (error) {
+      console.error(error);
+      this.hideHoverPreview();
+    }
+  }
+
+  private positionHoverPreview(mark: HTMLElement) {
+    const markRect = mark.getBoundingClientRect();
+    const wrapperRect = this.wrapper.getBoundingClientRect();
+
+    const top = markRect.bottom - wrapperRect.top + 8;
+    const left = markRect.left - wrapperRect.left;
+
+    this.preview.style.top = `${top}px`;
+    this.preview.style.left = `${left}px`;
+  }
+
+  private hideHoverPreview() {
+    this.preview.hidden = true;
+    this.preview.innerHTML = "";
+  }
+
+  private clearHoverTimer() {
+    if (this.hoverPreviewTimeoutId !== undefined) {
+      window.clearTimeout(this.hoverPreviewTimeoutId);
+      this.hoverPreviewTimeoutId = undefined;
     }
   }
 

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -1,6 +1,9 @@
 import "../scss/base.scss";
 import embedRegex from "./content-block/regex.ts";
-import { createHoverPreviewElement } from "./content-block/hover-preview-utils.ts";
+import {
+  createHoverPreviewElement,
+  makeIframePayload,
+} from "./content-block/hover-preview-utils.ts";
 import { APIClient } from "./content-block/api-client.ts";
 
 export interface ContentBlockEditorOptions {
@@ -47,6 +50,14 @@ export class ContentBlockEditor {
     this.textarea.addEventListener("mouseleave", () =>
       this.onTextareaMouseLeave(),
     );
+    window.addEventListener("message", (event) => {
+      if (event.data && event.data.type === "resize-preview") {
+        if (this.preview instanceof HTMLIFrameElement) {
+          this.preview.style.height = `${event.data.height + 4}px`;
+          this.preview.style.width = `${event.data.width + 4}px`;
+        }
+      }
+    });
 
     // checks for changes to the dimensions of the textarea, and syncs the scroll position of the highlight accordingly
     // see docs: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
@@ -178,7 +189,7 @@ export class ContentBlockEditor {
       const preview = await cachedPreviewPromise;
       if (this.activeHoverEmbedCode !== embedCode) return;
 
-      this.preview.srcdoc = preview.html;
+      this.preview.srcdoc = makeIframePayload(preview.html);
       this.positionHoverPreview(mark);
       this.preview.hidden = false;
       this.preview.setAttribute("aria-hidden", "false");

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -13,7 +13,7 @@ export class ContentBlockEditor {
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
-  preview: HTMLDivElement;
+  preview: HTMLIFrameElement;
   apiClient: APIClient;
   hoverPreviewTimeoutId?: number;
   activeHoverEmbedCode: string | null = null;
@@ -178,7 +178,7 @@ export class ContentBlockEditor {
       const preview = await cachedPreviewPromise;
       if (this.activeHoverEmbedCode !== embedCode) return;
 
-      this.preview.innerHTML = preview.html;
+      this.preview.srcdoc = preview.html;
       this.positionHoverPreview(mark);
       this.preview.hidden = false;
       this.preview.setAttribute("aria-hidden", "false");

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -195,6 +195,7 @@ export class ContentBlockEditor {
     const top = markRect.bottom - wrapperRect.top + 8;
     const left = markRect.left - wrapperRect.left;
 
+    this.preview.style.position = "absolute";
     this.preview.style.top = `${top}px`;
     this.preview.style.left = `${left}px`;
   }

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -20,7 +20,7 @@ export class ContentBlockEditor {
   currentMarkUnderCursor: HTMLElement | null = null;
 
   constructor(element: Element, options: ContentBlockEditorOptions) {
-    this.embedPreviewDelayMs = options?.embedPreviewDelayMs ?? 200;
+    this.embedPreviewDelayMs = options.embedPreviewDelayMs ?? 200;
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();
@@ -36,7 +36,10 @@ export class ContentBlockEditor {
     this.updateHighlight();
 
     this.textarea.addEventListener("input", () => this.updateHighlight());
-    this.textarea.addEventListener("scroll", () => this.syncScroll());
+    this.textarea.addEventListener("scroll", () => {
+      this.syncScroll();
+      this.onTextareaMouseLeave();
+    });
     this.textarea.addEventListener(
       "mousemove",
       (event) => void this.onTextareaMouseMove(event),
@@ -136,9 +139,10 @@ export class ContentBlockEditor {
   }
 
   getMarkUnderCursor(event: MouseEvent): HTMLElement | null {
+    const previousPointerEvents = this.textarea.style.pointerEvents;
     this.textarea.style.pointerEvents = "none";
     const el = document.elementFromPoint(event.clientX, event.clientY);
-    this.textarea.style.pointerEvents = "";
+    this.textarea.style.pointerEvents = previousPointerEvents;
     if (!(el instanceof Element)) return null;
     const mark = el.closest(".content-block-highlight__mark");
     return mark instanceof HTMLElement ? mark : null;
@@ -177,6 +181,7 @@ export class ContentBlockEditor {
       this.preview.innerHTML = preview.html;
       this.positionHoverPreview(mark);
       this.preview.hidden = false;
+      this.preview.setAttribute("aria-hidden", "false");
     } catch (error) {
       console.error(error);
       this.hideHoverPreview();
@@ -196,6 +201,7 @@ export class ContentBlockEditor {
 
   private hideHoverPreview() {
     this.preview.hidden = true;
+    this.preview.setAttribute("aria-hidden", "true");
     this.preview.innerHTML = "";
   }
 

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -1,28 +1,32 @@
 import "../scss/base.scss";
 import embedRegex from "./content-block/regex.ts";
 import { createHoverPreviewElement } from "./content-block/hover-preview-utils.ts";
+import { APIClient } from "./content-block/api-client.ts";
+
+export interface ContentBlockEditorOptions {
+  baseUrl: string;
+  embedPreviewDelayMs?: number;
+}
 
 export class ContentBlockEditor {
   readonly embedPreviewDelayMs: number;
-  readonly embedRenderEndpoint: string;
   textarea: HTMLTextAreaElement;
   wrapper: HTMLDivElement;
   highlight: HTMLDivElement;
   preview: HTMLDivElement;
+  apiClient: APIClient;
 
-  constructor(
-    element: Element,
-    embedPreviewDelayMs: number = 200,
-    embedRenderEndpoint: string = "/api/blocks/render",
-  ) {
-    this.embedPreviewDelayMs = embedPreviewDelayMs;
-    this.embedRenderEndpoint = embedRenderEndpoint;
+  constructor(element: Element, options: ContentBlockEditorOptions) {
+    this.embedPreviewDelayMs = options?.embedPreviewDelayMs ?? 200;
     this.textarea = this.initializeModule(element);
     this.wrapper = this.createWrapper();
     this.highlight = this.createHighlight();
 
     this.preview = createHoverPreviewElement();
     this.wrapper.appendChild(this.preview);
+
+    const baseUrl = options.baseUrl;
+    this.apiClient = new APIClient(baseUrl);
 
     this.textarea.classList.add("content-block-highlight__input");
 
@@ -92,15 +96,22 @@ export class ContentBlockEditor {
     );
 
     this.highlight.innerHTML = text;
+    const allEmbedCodes = text.matchAll(embedRegex);
+    for (const embedCode of allEmbedCodes) {
+      void this.apiClient.get(embedCode[0]).catch((e) => console.error(e));
+    }
   }
 
-  static initAll(scope: ParentNode = document): ContentBlockEditor[] {
+  static initAll(
+    options: ContentBlockEditorOptions,
+    scope: ParentNode = document,
+  ): ContentBlockEditor[] {
     const elements = scope.querySelectorAll(
       '[data-module~="content-block-highlight"]',
     );
 
     return Array.from(elements).map(
-      (element) => new ContentBlockEditor(element),
+      (element) => new ContentBlockEditor(element, options),
     );
   }
 }

--- a/src/content-block/api-client.spec.ts
+++ b/src/content-block/api-client.spec.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { APIClient } from "./api-client";
+
+interface BlockResponse {
+  html: string;
+}
+
+function createSuccessResponse(data: BlockResponse): Response {
+  const text = vi.fn().mockResolvedValue(data.html);
+  return {
+    ok: true,
+    status: 200,
+    text,
+  } as unknown as Response;
+}
+
+function createErrorResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    text: vi.fn(),
+  } as unknown as Response;
+}
+
+describe("APIClient", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const baseUrl = "https://example.test";
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  test("it fetches from the encoded block render URL", async () => {
+    const embedCode = "{{embed:contact:abc-123/some-path#full}}";
+    const expectedPayload: BlockResponse = { html: "<p>Rendered</p>" };
+    const expectedUrl = `${baseUrl}/api/blocks/${encodeURIComponent(embedCode)}/render`;
+    const client = new APIClient(baseUrl);
+
+    fetchMock.mockResolvedValue(createSuccessResponse(expectedPayload));
+
+    const result = await client.fetchPreview(embedCode);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(expectedUrl);
+    expect(result).toEqual(expectedPayload);
+  });
+
+  test("it reuses cached requests for the same embed code", async () => {
+    const embedCode = "{{embed:contact:abc-123}}";
+    const payload: BlockResponse = { html: "<p>Cached</p>" };
+    const client = new APIClient("http://not-used.test");
+
+    fetchMock.mockResolvedValue(createSuccessResponse(payload));
+
+    const firstResult = await client.fetchPreview(embedCode);
+    const secondResult = await client.fetchPreview(embedCode);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstResult).toEqual(payload);
+    expect(secondResult).toEqual(payload);
+  });
+
+  test("it removes failed requests from cache so retries can succeed", async () => {
+    const embedCode = "{{embed:contact:abc-123}}";
+    const client = new APIClient("http://not-used.test");
+    const payload: BlockResponse = { html: "<p>Retry worked</p>" };
+
+    fetchMock
+      .mockResolvedValueOnce(createErrorResponse(500))
+      .mockResolvedValueOnce(createSuccessResponse(payload));
+
+    await expect(client.fetchPreview(embedCode)).rejects.toThrow(
+      "Failed to fetch block {{embed:contact:abc-123}}: 500",
+    );
+
+    const result = await client.fetchPreview(embedCode);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(payload);
+  });
+
+  test("it returns a cached promise only when present", async () => {
+    const embedCode = "{{embed:contact:abc-123}}";
+    const payload: BlockResponse = { html: "<p>Cached lookup</p>" };
+    const client = new APIClient("http://not-used.test");
+
+    fetchMock.mockResolvedValue(createSuccessResponse(payload));
+
+    expect(client.get(embedCode)).toBeUndefined();
+
+    const pending = client.fetchPreview(embedCode);
+    expect(client.get(embedCode)).toBe(pending);
+    await expect(pending).resolves.toEqual(payload);
+  });
+
+  test("buildUrl encodes the embed code in the render path", () => {
+    const embedCode = "{{embed:contact:abc-123/somepath#full}}";
+    const client = new APIClient(baseUrl) as unknown as {
+      buildUrl: (embed: string) => string;
+    };
+
+    const result = client.buildUrl(embedCode);
+
+    expect(result).toBe(
+      `${baseUrl}/api/blocks/${encodeURIComponent(embedCode)}/render`,
+    );
+  });
+
+  test("buildUrl rejects URLs outside the configured base path", () => {
+    // bit of a fudge to test the URL validation logic without exposing buildUrl as a public method, but it allows us
+    // to verify that the client correctly rejects embed codes that would result in URLs outside the base path
+    const client = new APIClient("https://example.test/editor/") as unknown as {
+      buildUrl: (embed: string) => string;
+    };
+    expect(() => client.buildUrl("{{embed:contact:abcd-123}}")).toThrow(
+      "is not within the base path",
+    );
+  });
+
+  test("it rejects embed codes that do not match the supported syntax", async () => {
+    const client = new APIClient(baseUrl);
+
+    await expect(client.fetchPreview("not an embed code")).rejects.toThrow(
+      "Invalid embed code: not an embed code",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/content-block/api-client.ts
+++ b/src/content-block/api-client.ts
@@ -1,0 +1,87 @@
+/**
+ * Represents an embed code response from the API.
+ */
+export interface EmbedCodePreview {
+  html: string;
+}
+
+/**
+ * APIClient is a simple client for fetching rendered content blocks from the server.
+ *
+ * It includes an in-memory cache to avoid redundant network requests for the same embed
+ * code. The cache is keyed by the embed code string, and the values are Promises that
+ * resolve to the fetched data. This allows multiple concurrent requests for the same
+ * embed code to share the same Promise, preventing duplicate fetches.
+ */
+
+import { isValidEmbedCode } from "./regex.ts";
+
+export class APIClient {
+  private cache = new Map<string, Promise<EmbedCodePreview>>();
+  private readonly baseUrl: URL;
+  private readonly RENDER_PATH = "/api/blocks/:embedCode/render";
+
+  constructor(baseUrl: string) {
+    this.baseUrl = new URL(baseUrl);
+  }
+
+  fetchPreview(embedCode: string): Promise<EmbedCodePreview> {
+    if (this.cache.has(embedCode)) {
+      return this.cache.get(embedCode)!;
+    }
+
+    let url: string;
+    try {
+      url = this.buildUrl(embedCode);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    const promise = fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          this.cache.delete(embedCode);
+          throw new Error(
+            `Failed to fetch block ${embedCode}: ${response.status}`,
+          );
+        }
+
+        return response.text();
+      })
+      .then((html) => ({ html }))
+      .catch((error) => {
+        this.cache.delete(embedCode);
+        throw error;
+      });
+
+    this.cache.set(embedCode, promise);
+    return promise;
+  }
+
+  get(embedCode: string): Promise<EmbedCodePreview> | undefined {
+    return this.cache.get(embedCode);
+  }
+
+  private buildUrl(embedCode: string): string {
+    if (!isValidEmbedCode(embedCode)) {
+      throw new Error(`Invalid embed code: ${embedCode}`);
+    }
+
+    const path = this.RENDER_PATH.replace(
+      ":embedCode",
+      encodeURIComponent(embedCode),
+    );
+    const fullUrl = new URL(path, this.baseUrl);
+    if (fullUrl.origin !== this.baseUrl.origin) {
+      throw new Error(
+        `Invalid URL: ${fullUrl} is not on the same origin as ${this.baseUrl}`,
+      );
+    }
+    if (!fullUrl.pathname.startsWith(this.baseUrl.pathname)) {
+      throw new Error(
+        `Invalid URL: ${fullUrl} is not within the base path of ${this.baseUrl}`,
+      );
+    }
+    return fullUrl.toString();
+  }
+}

--- a/src/content-block/hover-preview-utils.spec.ts
+++ b/src/content-block/hover-preview-utils.spec.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { createHoverPreviewElement } from "./hover-preview-utils";
+
+describe("createHoverPreviewElement", () => {
+  let preview: HTMLDivElement;
+
+  beforeEach(() => {
+    preview = createHoverPreviewElement();
+  });
+
+  test("it returns an HTMLDivElement", () => {
+    expect(preview).toBeInstanceOf(HTMLDivElement);
+  });
+
+  test("it sets the className to content-block-highlight__preview", () => {
+    expect(preview.className).toBe("content-block-highlight__preview");
+  });
+
+  test("it sets the hidden attribute to true", () => {
+    expect(preview.hidden).toBe(true);
+  });
+
+  test("it sets the aria-hidden attribute to true", () => {
+    expect(preview.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("it creates an independent element each time", () => {
+    const previewTwo = createHoverPreviewElement();
+
+    expect(preview).not.toBe(previewTwo);
+    expect(preview.className).toBe(previewTwo.className);
+  });
+});

--- a/src/content-block/hover-preview-utils.spec.ts
+++ b/src/content-block/hover-preview-utils.spec.ts
@@ -1,33 +1,63 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { createHoverPreviewElement } from "./hover-preview-utils";
+import {
+  createHoverPreviewElement,
+  makeIframePayload,
+} from "./hover-preview-utils";
 
 describe("createHoverPreviewElement", () => {
-  let preview: HTMLDivElement;
+  let preview: HTMLIFrameElement;
 
   beforeEach(() => {
     preview = createHoverPreviewElement();
   });
 
-  test("it returns an HTMLDivElement", () => {
-    expect(preview).toBeInstanceOf(HTMLDivElement);
+  test("returns an iframe element", () => {
+    expect(preview.tagName).toBe("IFRAME");
   });
 
-  test("it sets the className to content-block-highlight__preview", () => {
-    expect(preview.className).toBe("content-block-highlight__preview");
+  test("applies the expected class name", () => {
+    expect(preview.className).toBe("content-block-highlight__preview-frame");
   });
 
-  test("it sets the hidden attribute to true", () => {
-    expect(preview.hidden).toBe(true);
+  test("sets the sandbox attribute to allow scripts", () => {
+    expect(preview.getAttribute("sandbox")).toBe("allow-scripts");
   });
 
-  test("it sets the aria-hidden attribute to true", () => {
-    expect(preview.getAttribute("aria-hidden")).toBe("true");
+  test("applies the expected inline styles", () => {
+    expect(preview.style.width).toBe("300px");
+    expect(preview.style.height).toBe("0px");
+    expect(preview.style.borderStyle).toBe("none");
+    expect(preview.style.pointerEvents).toBe("none");
+  });
+});
+
+describe("makeIframePayload", () => {
+  test("injects the provided HTML inside the preview content container", () => {
+    const html = "<p>Preview block</p>";
+
+    const payload = makeIframePayload(html);
+
+    expect(payload).toContain(`<div id="preview-content">${html}</div>`);
   });
 
-  test("it creates an independent element each time", () => {
-    const previewTwo = createHoverPreviewElement();
+  test("includes the script that posts resize messages", () => {
+    const payload = makeIframePayload("<span>Example</span>");
 
-    expect(preview).not.toBe(previewTwo);
-    expect(preview.className).toBe(previewTwo.className);
+    expect(payload).toContain("type: 'resize-preview'");
+    expect(payload).toContain("window.parent.postMessage");
+    expect(payload).toContain(
+      "window.addEventListener('load', updateDimensions)",
+    );
+    expect(payload).toContain("ResizeObserver");
+  });
+
+  test("returns a complete html document string", () => {
+    const payload = makeIframePayload("<strong>Hi</strong>");
+
+    expect(payload).toContain("<!DOCTYPE html>");
+    expect(payload).toContain("<html>");
+    expect(payload).toContain("<head>");
+    expect(payload).toContain("<body>");
+    expect(payload).toContain("</html>");
   });
 });

--- a/src/content-block/hover-preview-utils.ts
+++ b/src/content-block/hover-preview-utils.ts
@@ -1,0 +1,7 @@
+export const createHoverPreviewElement = (): HTMLDivElement => {
+  const preview = document.createElement("div");
+  preview.className = "content-block-highlight__preview";
+  preview.hidden = true;
+  preview.setAttribute("aria-hidden", "true");
+  return preview;
+};

--- a/src/content-block/hover-preview-utils.ts
+++ b/src/content-block/hover-preview-utils.ts
@@ -2,9 +2,45 @@ export const createHoverPreviewElement = (): HTMLIFrameElement => {
   const iframe = document.createElement("iframe");
   iframe.className = "content-block-highlight__preview-frame";
 
-  // STRICT SANDBOX: Enables nothing except document rendering.
-  // No scripts, no forms, no same-origin cookie access.
-  iframe.setAttribute("sandbox", "");
-
+  iframe.setAttribute("sandbox", "allow-scripts");
+  iframe.style.width = "300px";
+  iframe.style.height = "0px";
+  iframe.style.border = "none";
+  iframe.style.pointerEvents = "none";
   return iframe;
+};
+
+export const makeIframePayload = (html: string): string => {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <style>
+          body { margin: 0; padding: 3px; overflow: hidden; font-family: sans-serif; }
+          #preview-content { display: inline-block; }
+        </style>
+      </head>
+      <body>
+        <div id="preview-content">${html}</div>
+        <script>const updateDimensions = () => {
+              const el = document.getElementById('preview-content');
+              
+              const height = el.offsetHeight;
+              const width = el.offsetWidth;
+              
+              window.parent.postMessage({ 
+                type: 'resize-preview', 
+                height: height, 
+                width: width 
+              }, '*');
+            };
+            
+            window.addEventListener('load', updateDimensions);
+            if ('ResizeObserver' in window) {
+              new ResizeObserver(updateDimensions).observe(document.body);
+            }
+        </script>
+      </body>
+    </html> 
+    `;
 };

--- a/src/content-block/hover-preview-utils.ts
+++ b/src/content-block/hover-preview-utils.ts
@@ -1,7 +1,10 @@
-export const createHoverPreviewElement = (): HTMLDivElement => {
-  const preview = document.createElement("div");
-  preview.className = "content-block-highlight__preview";
-  preview.hidden = true;
-  preview.setAttribute("aria-hidden", "true");
-  return preview;
-};
+export const createHoverPreviewElement = (): HTMLIFrameElement => {
+  const iframe = document.createElement("iframe");
+  iframe.className = "content-block-highlight__preview-frame";
+
+  // STRICT SANDBOX: Enables nothing except document rendering.
+  // No scripts, no forms, no same-origin cookie access.
+  iframe.setAttribute("sandbox", "");
+
+  return iframe;
+}

--- a/src/content-block/hover-preview-utils.ts
+++ b/src/content-block/hover-preview-utils.ts
@@ -7,4 +7,4 @@ export const createHoverPreviewElement = (): HTMLIFrameElement => {
   iframe.setAttribute("sandbox", "");
 
   return iframe;
-}
+};

--- a/src/content-block/regex.test.ts
+++ b/src/content-block/regex.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "vitest";
-import regex from "./regex.ts";
+import regex, { isValidEmbedCode } from "./regex.ts";
 
 describe("regex", () => {
   afterEach(() => {
@@ -107,5 +107,18 @@ describe("regex", () => {
     expect(result![0]).toEqual(
       "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab}}",
     );
+  });
+
+  test("validates full embed codes only", () => {
+    expect(
+      isValidEmbedCode(
+        "{{embed:content_block_pension:1690ab79-1880-461e-99e4-ed146fd9efab}}",
+      ),
+    ).toBe(true);
+
+    expect(isValidEmbedCode("prefix {{embed:contact:abc-123}} suffix")).toBe(
+      false,
+    );
+    expect(isValidEmbedCode("not an embed code")).toBe(false);
   });
 });

--- a/src/content-block/regex.ts
+++ b/src/content-block/regex.ts
@@ -30,4 +30,9 @@ const pattern = [
 
 const embedRegex = new RegExp(pattern, "g");
 
+const embedCodeRegex = new RegExp(`^${pattern}$`);
+
+export const isValidEmbedCode = (embedCode: string): boolean =>
+  embedCodeRegex.test(embedCode);
+
 export default embedRegex;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,19 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
 
+const cbmEndpoint =
+  process.env.CBM_ENDPOINT || "http://content-block-manager.dev.gov.uk";
+
 export default defineConfig({
+  server: {
+    proxy: {
+      "/api": {
+        target: cbmEndpoint,
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   build: {
     lib: {
       entry: resolve(__dirname, "src/content-block-editor.ts"),


### PR DESCRIPTION
## What

This PR adds hover previews for content block embeds within the editor.

It introduces a dedicated API client for fetching rendered previews, adds utilities for preview element initialisation, and updates the editor to use explicit configuration for preview requests.

The preview is rendered inside a sandboxed `iframe` rather than directly into the page. This provides better isolation for returned HTML and reduces the risk of the preview affecting the parent document.

The change also includes preview positioning and interaction handling so that previews are displayed in the right place, resize correctly after rendering, and do not interfere with normal editor behaviour.

## Why

This work improves the editing experience by allowing users to inspect embedded content blocks without leaving the editor.

It also makes the implementation safe and easy to maintain by:
- separating preview fetching into a dedicated API client
- reducing repeated network requests through simple caching
- isolating rendered preview HTML in a sandboxed `iframe`
- addressing interaction issues around hover, scrolling and preview sizing

## How

- added hover-based preview rendering for embedded content blocks
- introduced a caching API client for preview render requests
- refactored editor initialisation to use an options object, including explicit `baseUrl` configuration
- added preview initialisation utilities
- addedd preview rendering in a sandboxed `iframe`
- positioned previews beneath the related highlighted block
- added messaging so the preview can report its rendered size and the parent can resize the `iframe`
- improved mouse and scroll handling to prevent stale or stuck previews
- updated documentation, examples and local development configuration to support the new behaviour

## Testing

- added and updated unit tests for:
  - editor preview behaviour
  - preview initialisation utilities
  - hover preview utilities
  - API client caching, validation and retry behaviour
- updated related tests for configuration changes and base URL propagation

## Screenshots / before and after

<img width="1054" height="559" alt="Screenshot 2026-06-23 at 10 13 39" src="https://github.com/user-attachments/assets/cc566885-9efe-4939-a68f-40777e95286f" />

## Ticket

[CM-966](https://gov-uk.atlassian.net/browse/CM-966)

[CM-966]: https://gov-uk.atlassian.net/browse/CM-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ