### PR TITLE
CM-970: List available content blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ ContentBlockEditor.initAll({
 });
 ```
 
+### Listing available blocks
+
+The picker can show editors the content blocks available to them so they don't need to know an embed code up front. Add a trigger button and point the textarea at it with the `data-cbp-insert-block-button` attribute, set to the button's `id`:
+
+```html
+<button id="insert-content-block-button">Insert block</button>
+<textarea
+  data-module="content-block-highlight"
+  data-cbp-insert-block-button="insert-content-block-button"
+></textarea>
+```
+
+Clicking the button opens an overlay that fetches the blocks from `GET {baseUrl}/api/blocks` and lists each one by title, with its available formats nested underneath. The list is loaded fresh each time it is opened (so it always reflects the current state of the blocks) and is dismissed by pressing `Escape`, clicking the list, or clicking anywhere outside it.
+
+Each textarea is wired to its own button, so multiple editors can appear on the same page. The attribute is optional — omit it and the picker behaves exactly as before.
+
 ## Demo
 
 You can see a [demo of the work so far here](https://alphagov.github.io/content-block-editor/)

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -79,3 +79,142 @@ test.describe("Content Block Editor", () => {
     expect(html).toContain('<mark class="content-block-highlight__mark">');
   });
 });
+
+test.describe("List available blocks", () => {
+  test("it fetches and displays blocks when the insert button is clicked", async ({
+    page,
+  }) => {
+    const mockBlocks = {
+      results: [
+        {
+          title: "Pension Block A",
+          block_type: "Pension",
+          organisation: {
+            name: "Test Org",
+            content_id: "test-id-1",
+          },
+          state: "published",
+          embed_code: "{{embed:content_block_pension:abc123}}",
+          formats: [],
+        },
+        {
+          title: "Time Period Block B",
+          block_type: "Time period",
+          organisation: {
+            name: "Test Org",
+            content_id: "test-id-2",
+          },
+          state: "published",
+          embed_code: "{{embed:content_block_time_period:def456}}",
+          formats: ["long_form", "years"],
+        },
+      ],
+    };
+
+    // Set up network interception for the blocks endpoint
+    await page.route(/\/api\/blocks$/, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockBlocks),
+      });
+    });
+
+    const insertButton = page.locator("#insert-content-block-button");
+    const blockList = page.locator(".content-block-highlight__block-list");
+
+    // Block list should be hidden initially
+    await expect(blockList).toHaveAttribute("aria-hidden", "true");
+
+    // Click the insert button
+    await insertButton.click();
+
+    // Block list should be visible with loading state
+    await expect(blockList).toHaveAttribute("aria-hidden", "false");
+
+    // Wait for the blocks to load and be displayed
+    const topLevelList = blockList.locator("ul").first();
+    await expect(topLevelList).toBeVisible();
+    await expect(topLevelList.locator("> li")).toHaveCount(2);
+
+    // Check first block (no formats)
+    const firstBlock = topLevelList.locator("> li").first();
+    await expect(firstBlock).toContainText("Pension Block A");
+
+    // Check second block (with formats)
+    const secondBlock = topLevelList.locator("> li").nth(1);
+    await expect(secondBlock).toContainText("Time Period Block B");
+
+    // Check that formats are displayed as nested list for second block
+    const secondBlockFormatsList = secondBlock.locator("ul");
+    await expect(secondBlockFormatsList).toBeVisible();
+    await expect(secondBlockFormatsList.locator("li")).toHaveCount(2);
+    await expect(secondBlockFormatsList).toContainText("long_form");
+    await expect(secondBlockFormatsList).toContainText("years");
+  });
+
+  test("it hides the block list when clicking outside of it", async ({
+    page,
+  }) => {
+    const mockBlocks = {
+      results: [
+        {
+          title: "Test Block",
+          block_type: "Pension",
+          organisation: {
+            name: "Test Org",
+            content_id: "test-id",
+          },
+          state: "published",
+          embed_code: "{{embed:content_block_pension:test}}",
+          formats: [],
+        },
+      ],
+    };
+
+    await page.route(/\/api\/blocks$/, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockBlocks),
+      });
+    });
+
+    const insertButton = page.locator("#insert-content-block-button");
+    const blockList = page.locator(".content-block-highlight__block-list");
+    const textarea = page.locator("textarea.content-block-highlight__input");
+
+    // Click the insert button to show the block list
+    await insertButton.click();
+    await expect(blockList).toHaveAttribute("aria-hidden", "false");
+
+    // Click outside the block list (on the textarea)
+    await textarea.click();
+
+    // Block list should be hidden
+    await expect(blockList).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test("it displays an error message when block fetch fails", async ({
+    page,
+  }) => {
+    // Mock the API endpoint to return a 500 error
+    await page.route(/\/api\/blocks$/, (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Internal Server Error" }),
+      });
+    });
+
+    const insertButton = page.locator("#insert-content-block-button");
+    const blockList = page.locator(".content-block-highlight__block-list");
+
+    // Click the insert button
+    await insertButton.click();
+
+    // Block list should be visible with error message
+    await expect(blockList).toHaveAttribute("aria-hidden", "false");
+    await expect(blockList).toContainText("Unable to load blocks.");
+  });
+});

--- a/index.html
+++ b/index.html
@@ -68,9 +68,13 @@
       <main class="govuk-main-wrapper" id="main-content">
         <div id="app">
           <h1 class="govuk-heading-xl">Content Block Editor</h1>
+          <button class="govuk-button" id="insert-content-block-button">
+            Insert block
+          </button>
           <textarea
             class="my-textarea govuk-textarea"
             data-module="content-block-highlight"
+            data-cbp-insert-block-button="insert-content-block-button"
           ></textarea>
         </div>
       </main>

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -41,7 +41,7 @@ textarea.content-block-highlight__input {
 }
 
 .content-block-highlight__block-list {
-  position: fixed;
+  position: absolute;
   z-index: 1000;
   padding: 8px 12px;
   border: 1px solid $govuk-border-colour;

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -39,3 +39,12 @@ textarea.content-block-highlight__input {
   background: $govuk-body-background-colour;
   box-shadow: 0 2px 8px rgb(11 12 12 / 20%);
 }
+
+.content-block-highlight__block-list {
+  position: fixed;
+  z-index: 1000;
+  padding: 8px 12px;
+  border: 1px solid $govuk-border-colour;
+  background: $govuk-body-background-colour;
+  box-shadow: 0 2px 8px rgb(11 12 12 / 15%);
+}

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -243,6 +243,183 @@ describe("ContentBlockPicker", () => {
 
       expect(observeSpy).toHaveBeenCalledWith(textarea);
     });
+
+    test("it shows a block list when the configured insert button is clicked", () => {
+      document.body.innerHTML = `
+        <button id="insert-content-block-button">Insert block</button>
+        <textarea
+          id="my-textarea"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button"
+        ></textarea>
+      `;
+
+      const textareaWithButton = document.getElementById(
+        "my-textarea",
+      ) as HTMLTextAreaElement;
+      const insertButton = document.getElementById(
+        "insert-content-block-button",
+      ) as HTMLButtonElement;
+
+      const editorInstance = new ContentBlockEditor(textareaWithButton, {
+        baseUrl,
+      });
+
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+
+      insertButton.click();
+
+      expect(editorInstance.blockListElement.hidden).toBe(false);
+      expect(editorInstance.blockListElement.textContent).toBe("Block list");
+      expect(editorInstance.blockListElement.getAttribute("aria-hidden")).toBe(
+        "false",
+      );
+    });
+
+    test("it hides the block list when escape is pressed", () => {
+      document.body.innerHTML = `
+        <button id="insert-content-block-button">Insert block</button>
+        <textarea
+          id="my-textarea"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button"
+        ></textarea>
+      `;
+
+      const textareaWithButton = document.getElementById(
+        "my-textarea",
+      ) as HTMLTextAreaElement;
+      const insertButton = document.getElementById(
+        "insert-content-block-button",
+      ) as HTMLButtonElement;
+
+      const editorInstance = new ContentBlockEditor(textareaWithButton, {
+        baseUrl,
+      });
+
+      insertButton.click();
+      expect(editorInstance.blockListElement.hidden).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+      expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
+        "true",
+      );
+    });
+
+    test("it hides the block list when the block list is clicked", () => {
+      document.body.innerHTML = `
+        <button id="insert-content-block-button">Insert block</button>
+        <textarea
+          id="my-textarea"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button"
+        ></textarea>
+      `;
+
+      const textareaWithButton = document.getElementById(
+        "my-textarea",
+      ) as HTMLTextAreaElement;
+      const insertButton = document.getElementById(
+        "insert-content-block-button",
+      ) as HTMLButtonElement;
+
+      const editorInstance = new ContentBlockEditor(textareaWithButton, {
+        baseUrl,
+      });
+
+      insertButton.click();
+      expect(editorInstance.blockListElement?.hidden).toBe(false);
+
+      editorInstance.blockListElement?.click();
+
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+      expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
+        "true",
+      );
+    });
+
+    test("it hides the block list when clicking outside the block list", () => {
+      document.body.innerHTML = `
+        <button id="insert-content-block-button">Insert block</button>
+        <textarea
+          id="my-textarea"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button"
+        ></textarea>
+      `;
+
+      const textareaWithButton = document.getElementById(
+        "my-textarea",
+      ) as HTMLTextAreaElement;
+      const insertButton = document.getElementById(
+        "insert-content-block-button",
+      ) as HTMLButtonElement;
+
+      const editorInstance = new ContentBlockEditor(textareaWithButton, {
+        baseUrl,
+      });
+
+      insertButton.click();
+      expect(editorInstance.blockListElement?.hidden).toBe(false);
+
+      document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+      expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
+        "true",
+      );
+    });
+  });
+
+  describe("multiple editors with insert buttons", () => {
+    test("it binds each editor instance to its own insert button", () => {
+      document.body.innerHTML = `
+        <button id="insert-content-block-button-1">Insert block 1</button>
+        <textarea
+          id="my-textarea-1"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button-1"
+        ></textarea>
+
+        <button id="insert-content-block-button-2">Insert block 2</button>
+        <textarea
+          id="my-textarea-2"
+          data-module="content-block-highlight"
+          data-cbp-insert-block-button="insert-content-block-button-2"
+        ></textarea>
+      `;
+
+      const insertButtonOne = document.getElementById(
+        "insert-content-block-button-1",
+      ) as HTMLButtonElement;
+      const insertButtonTwo = document.getElementById(
+        "insert-content-block-button-2",
+      ) as HTMLButtonElement;
+
+      const [firstEditor, secondEditor] = ContentBlockEditor.initAll({
+        baseUrl,
+      });
+
+      expect(firstEditor.blockListElement?.hidden).toBe(true);
+      expect(secondEditor.blockListElement?.hidden).toBe(true);
+
+      insertButtonOne.click();
+
+      expect(firstEditor.blockListElement?.hidden).toBe(false);
+      expect(secondEditor.blockListElement?.hidden).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+      expect(firstEditor.blockListElement?.hidden).toBe(true);
+      expect(secondEditor.blockListElement?.hidden).toBe(true);
+
+      insertButtonTwo.click();
+
+      expect(firstEditor.blockListElement?.hidden).toBe(true);
+      expect(secondEditor.blockListElement?.hidden).toBe(false);
+    });
   });
 
   describe("initAll", () => {

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, describe, beforeEach, vi } from "vitest";
 import { ContentBlockEditor } from "./content-block-editor.ts";
+import type { ContentBlock } from "./content-block/api-client.ts";
 
 describe("ContentBlockPicker", () => {
   let textarea: HTMLTextAreaElement;
@@ -7,6 +8,30 @@ describe("ContentBlockPicker", () => {
 
   const embedPreviewDelayMs = 314;
   const baseUrl = "http://not-used.test";
+  const sampleBlocks: ContentBlock[] = [
+    {
+      title: "Sample Pension Block 1",
+      block_type: "Pension",
+      organisation: {
+        name: "AI Security Institute",
+        content_id: "11111111-2222-3333-4444-000000000000",
+      },
+      state: "published",
+      embed_code: "{{embed:content_block_pension:sample-pension-1}}",
+      formats: [],
+    },
+    {
+      title: "Sample Time Period Block 1",
+      block_type: "Time period",
+      organisation: {
+        name: "AI Security Institute",
+        content_id: "11111111-2222-3333-4444-000000000001",
+      },
+      state: "published",
+      embed_code: "{{embed:content_block_time_period:sample-time-1}}",
+      formats: ["long_form", "years"],
+    },
+  ];
 
   function mockSuccessFetch() {
     const fetchMock = vi.fn().mockResolvedValue({
@@ -17,6 +42,29 @@ describe("ContentBlockPicker", () => {
 
     vi.stubGlobal("fetch", fetchMock);
     return fetchMock;
+  }
+
+  function setupEditorWithInsertButton() {
+    document.body.innerHTML = `
+      <button id="insert-content-block-button">Insert block</button>
+      <textarea
+        id="my-textarea"
+        data-module="content-block-highlight"
+        data-cbp-insert-block-button="insert-content-block-button"
+      ></textarea>
+    `;
+
+    const textareaWithButton = document.getElementById(
+      "my-textarea",
+    ) as HTMLTextAreaElement;
+    const insertButton = document.getElementById(
+      "insert-content-block-button",
+    ) as HTMLButtonElement;
+    const editorInstance = new ContentBlockEditor(textareaWithButton, {
+      baseUrl,
+    });
+
+    return { textareaWithButton, insertButton, editorInstance };
   }
 
   beforeEach(() => {
@@ -244,61 +292,113 @@ describe("ContentBlockPicker", () => {
       expect(observeSpy).toHaveBeenCalledWith(textarea);
     });
 
-    test("it shows a block list when the configured insert button is clicked", () => {
-      document.body.innerHTML = `
-        <button id="insert-content-block-button">Insert block</button>
-        <textarea
-          id="my-textarea"
-          data-module="content-block-highlight"
-          data-cbp-insert-block-button="insert-content-block-button"
-        ></textarea>
-      `;
-
-      const textareaWithButton = document.getElementById(
-        "my-textarea",
-      ) as HTMLTextAreaElement;
-      const insertButton = document.getElementById(
-        "insert-content-block-button",
-      ) as HTMLButtonElement;
-
-      const editorInstance = new ContentBlockEditor(textareaWithButton, {
-        baseUrl,
-      });
+    test("it shows a fetching message and then renders blocks when the configured insert button is clicked", async () => {
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      const fetchAllBlocksMock = vi
+        .spyOn(editorInstance.apiClient, "fetchAllBlocks")
+        .mockResolvedValue(sampleBlocks);
 
       expect(editorInstance.blockListElement?.hidden).toBe(true);
 
       insertButton.click();
 
-      expect(editorInstance.blockListElement.hidden).toBe(false);
-      expect(editorInstance.blockListElement.textContent).toBe("Block list");
-      expect(editorInstance.blockListElement.getAttribute("aria-hidden")).toBe(
+      expect(fetchAllBlocksMock).toHaveBeenCalledTimes(1);
+      expect(editorInstance.blockListElement?.hidden).toBe(false);
+      expect(editorInstance.blockListElement?.textContent).toBe(
+        "Fetching blocks...",
+      );
+      expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
         "false",
       );
+
+      await vi.waitFor(() => {
+        const topLevelList =
+          editorInstance.blockListElement?.querySelector("ul");
+        expect(topLevelList).not.toBeNull();
+        expect(topLevelList?.children).toHaveLength(2);
+      });
+
+      const topLevelList = editorInstance.blockListElement?.querySelector(
+        "ul",
+      ) as HTMLUListElement;
+      const topLevelItems = Array.from(
+        topLevelList.children,
+      ) as HTMLLIElement[];
+
+      expect(topLevelItems[0].childNodes[0]?.textContent).toBe(
+        "Sample Pension Block 1",
+      );
+      expect(topLevelItems[0].querySelector("ul")).toBeNull();
+      expect(topLevelItems[1].childNodes[0]?.textContent).toBe(
+        "Sample Time Period Block 1",
+      );
+      expect(
+        Array.from(topLevelItems[1].querySelectorAll("ul > li")).map(
+          (item) => item.textContent,
+        ),
+      ).toEqual(["long_form", "years"]);
     });
 
-    test("it hides the block list when escape is pressed", () => {
-      document.body.innerHTML = `
-        <button id="insert-content-block-button">Insert block</button>
-        <textarea
-          id="my-textarea"
-          data-module="content-block-highlight"
-          data-cbp-insert-block-button="insert-content-block-button"
-        ></textarea>
-      `;
+    test("it positions the block list relative to the document, accounting for scroll", () => {
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
 
-      const textareaWithButton = document.getElementById(
-        "my-textarea",
-      ) as HTMLTextAreaElement;
-      const insertButton = document.getElementById(
-        "insert-content-block-button",
-      ) as HTMLButtonElement;
+      vi.spyOn(insertButton, "getBoundingClientRect").mockReturnValue({
+        bottom: 100,
+        left: 40,
+      } as DOMRect);
+      vi.spyOn(window, "scrollY", "get").mockReturnValue(500);
+      vi.spyOn(window, "scrollX", "get").mockReturnValue(30);
 
-      const editorInstance = new ContentBlockEditor(textareaWithButton, {
-        baseUrl,
+      insertButton.click();
+
+      // top = bottom (100) + scrollY (500) + 8px gap; left = left (40) + scrollX (30)
+      expect(editorInstance.blockListElement?.style.top).toBe("608px");
+      expect(editorInstance.blockListElement?.style.left).toBe("70px");
+    });
+
+    test("it does not start a second block fetch while the first one is in flight", async () => {
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      let resolveBlocks: (blocks: ContentBlock[]) => void = () => {};
+      const pendingBlocks = new Promise<ContentBlock[]>((resolve) => {
+        resolveBlocks = resolve;
+      });
+
+      const fetchAllBlocksMock = vi
+        .spyOn(editorInstance.apiClient, "fetchAllBlocks")
+        .mockReturnValue(pendingBlocks);
+
+      insertButton.click();
+      insertButton.click();
+
+      expect(fetchAllBlocksMock).toHaveBeenCalledTimes(1);
+      expect(editorInstance.blockListElement?.textContent).toBe(
+        "Fetching blocks...",
+      );
+
+      resolveBlocks(sampleBlocks);
+
+      await vi.waitFor(() => {
+        expect(editorInstance.blockListElement?.textContent).toContain(
+          "Sample Pension Block 1",
+        );
       });
 
       insertButton.click();
-      expect(editorInstance.blockListElement.hidden).toBe(false);
+
+      expect(fetchAllBlocksMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("it hides the block list when escape is pressed", () => {
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      insertButton.click();
+      expect(editorInstance.blockListElement?.hidden).toBe(false);
 
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
 
@@ -309,25 +409,10 @@ describe("ContentBlockPicker", () => {
     });
 
     test("it hides the block list when the block list is clicked", () => {
-      document.body.innerHTML = `
-        <button id="insert-content-block-button">Insert block</button>
-        <textarea
-          id="my-textarea"
-          data-module="content-block-highlight"
-          data-cbp-insert-block-button="insert-content-block-button"
-        ></textarea>
-      `;
-
-      const textareaWithButton = document.getElementById(
-        "my-textarea",
-      ) as HTMLTextAreaElement;
-      const insertButton = document.getElementById(
-        "insert-content-block-button",
-      ) as HTMLButtonElement;
-
-      const editorInstance = new ContentBlockEditor(textareaWithButton, {
-        baseUrl,
-      });
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
 
       insertButton.click();
       expect(editorInstance.blockListElement?.hidden).toBe(false);
@@ -341,25 +426,10 @@ describe("ContentBlockPicker", () => {
     });
 
     test("it hides the block list when clicking outside the block list", () => {
-      document.body.innerHTML = `
-        <button id="insert-content-block-button">Insert block</button>
-        <textarea
-          id="my-textarea"
-          data-module="content-block-highlight"
-          data-cbp-insert-block-button="insert-content-block-button"
-        ></textarea>
-      `;
-
-      const textareaWithButton = document.getElementById(
-        "my-textarea",
-      ) as HTMLTextAreaElement;
-      const insertButton = document.getElementById(
-        "insert-content-block-button",
-      ) as HTMLButtonElement;
-
-      const editorInstance = new ContentBlockEditor(textareaWithButton, {
-        baseUrl,
-      });
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
 
       insertButton.click();
       expect(editorInstance.blockListElement?.hidden).toBe(false);
@@ -401,6 +471,12 @@ describe("ContentBlockPicker", () => {
       const [firstEditor, secondEditor] = ContentBlockEditor.initAll({
         baseUrl,
       });
+      vi.spyOn(firstEditor.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+      vi.spyOn(secondEditor.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
 
       expect(firstEditor.blockListElement?.hidden).toBe(true);
       expect(secondEditor.blockListElement?.hidden).toBe(true);

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -5,6 +5,7 @@ import {
   makeIframePayload,
 } from "./content-block/hover-preview-utils.ts";
 import { APIClient } from "./content-block/api-client.ts";
+import type { ContentBlock } from "./content-block/api-client.ts";
 
 export interface ContentBlockEditorOptions {
   baseUrl: string;
@@ -21,7 +22,8 @@ export class ContentBlockEditor {
   hoverPreviewTimeoutId?: number;
   activeHoverEmbedCode: string | null = null;
   currentMarkUnderCursor: HTMLElement | null = null;
-  blockListElement: HTMLDivElement;
+  blockListElement: HTMLDivElement | null = null;
+  blockListRequest?: Promise<ContentBlock[]>;
 
   constructor(element: Element, options: ContentBlockEditorOptions) {
     this.embedPreviewDelayMs = options.embedPreviewDelayMs ?? 200;
@@ -110,7 +112,6 @@ export class ContentBlockEditor {
     const blockListPlaceholder = document.createElement("div");
     blockListPlaceholder.className = "content-block-highlight__block-list";
     blockListPlaceholder.hidden = true;
-    blockListPlaceholder.textContent = "Block list";
     blockListPlaceholder.setAttribute("role", "dialog");
     blockListPlaceholder.setAttribute("aria-hidden", "true");
     blockListPlaceholder.setAttribute("aria-label", "Insert content block");
@@ -160,15 +161,77 @@ export class ContentBlockEditor {
     blockListElement: HTMLDivElement,
   ) {
     const buttonRect = button.getBoundingClientRect();
-    this.blockListElement.style.top = `${buttonRect.bottom + window.scrollY + 8}px`;
-    this.blockListElement.style.left = `${buttonRect.left + window.scrollX}px`;
-    this.blockListElement.hidden = false;
-    this.blockListElement.setAttribute("aria-hidden", "false");
+    const topMargin = 8;
+    blockListElement.style.top = `${buttonRect.bottom + window.scrollY + topMargin}px`;
+    blockListElement.style.left = `${buttonRect.left + window.scrollX}px`;
+    blockListElement.replaceChildren(
+      document.createTextNode("Fetching blocks..."),
+    );
+    this.showElement(blockListElement);
+    void this.fetchAndRenderBlockList();
   }
 
   showElement(blockListElement: HTMLElement) {
     blockListElement.hidden = false;
     blockListElement.setAttribute("aria-hidden", "false");
+  }
+
+  hideElement(blockListElement: HTMLElement) {
+    blockListElement.hidden = true;
+    blockListElement.setAttribute("aria-hidden", "true");
+  }
+
+  private renderBlockListErrorState() {
+    this.blockListElement?.replaceChildren(
+      document.createTextNode("Unable to load blocks."),
+    );
+  }
+
+  private renderBlockList(blocks: ContentBlock[]) {
+    if (!this.blockListElement) return;
+
+    const blockList = document.createElement("ul");
+
+    for (const block of blocks) {
+      const blockItem = document.createElement("li");
+      blockItem.append(document.createTextNode(block.title));
+
+      if (block.formats.length > 0) {
+        const formatsList = document.createElement("ul");
+
+        for (const format of block.formats) {
+          const formatItem = document.createElement("li");
+          formatItem.textContent = format;
+          formatsList.appendChild(formatItem);
+        }
+
+        blockItem.appendChild(formatsList);
+      }
+
+      blockList.appendChild(blockItem);
+    }
+
+    this.blockListElement.replaceChildren(blockList);
+  }
+
+  private async fetchAndRenderBlockList() {
+    if (this.blockListRequest) {
+      return;
+    }
+
+    this.blockListRequest = this.apiClient.fetchAllBlocks();
+
+    try {
+      const blocks = await this.blockListRequest;
+      this.renderBlockList(blocks);
+    } catch (error) {
+      console.error(error);
+      this.renderBlockListErrorState();
+    } finally {
+      if (this.blockListRequest === this.blockListRequest) {
+        this.blockListRequest = undefined;
+      }
+    }
   }
 
   updateHighlight() {
@@ -262,8 +325,7 @@ export class ContentBlockEditor {
 
       this.preview.srcdoc = makeIframePayload(preview.html);
       this.positionHoverPreview(mark);
-      this.preview.hidden = false;
-      this.preview.setAttribute("aria-hidden", "false");
+      this.showElement(this.preview);
     } catch (error) {
       console.error(error);
       this.hideHoverPreview();

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -21,6 +21,7 @@ export class ContentBlockEditor {
   hoverPreviewTimeoutId?: number;
   activeHoverEmbedCode: string | null = null;
   currentMarkUnderCursor: HTMLElement | null = null;
+  blockListElement: HTMLDivElement;
 
   constructor(element: Element, options: ContentBlockEditorOptions) {
     this.embedPreviewDelayMs = options.embedPreviewDelayMs ?? 200;
@@ -50,6 +51,11 @@ export class ContentBlockEditor {
     this.textarea.addEventListener("mouseleave", () =>
       this.onTextareaMouseLeave(),
     );
+    if (this.textarea.dataset.cbpInsertBlockButton) {
+      this.blockListElement = this.createBlockListElement();
+      this.attachInsertBlockButtonListener(this.blockListElement);
+      this.attachBlockListHideListeners(this.blockListElement);
+    }
     window.addEventListener("message", (event) => {
       if (event.data && event.data.type === "resize-preview") {
         if (this.preview instanceof HTMLIFrameElement) {
@@ -98,6 +104,71 @@ export class ContentBlockEditor {
     this.wrapper.appendChild(highlight);
 
     return highlight;
+  }
+
+  createBlockListElement(): HTMLDivElement {
+    const blockListPlaceholder = document.createElement("div");
+    blockListPlaceholder.className = "content-block-highlight__block-list";
+    blockListPlaceholder.hidden = true;
+    blockListPlaceholder.textContent = "Block list";
+    blockListPlaceholder.setAttribute("role", "dialog");
+    blockListPlaceholder.setAttribute("aria-hidden", "true");
+    blockListPlaceholder.setAttribute("aria-label", "Insert content block");
+
+    document.body.appendChild(blockListPlaceholder);
+
+    return blockListPlaceholder;
+  }
+
+  attachInsertBlockButtonListener(blockListElement: HTMLDivElement) {
+    const buttonId = this.textarea.dataset.cbpInsertBlockButton;
+    if (!buttonId) return;
+
+    const button = document.getElementById(buttonId);
+    if (!(button instanceof HTMLButtonElement)) return;
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (blockListElement) {
+        this.showBlockListElement(button, blockListElement);
+      }
+    });
+  }
+
+  attachBlockListHideListeners(blockListElement: HTMLDivElement) {
+    blockListElement.addEventListener("click", () => {
+      this.hideElement(blockListElement);
+    });
+
+    document.addEventListener("click", (event) => {
+      if (blockListElement.hidden) return;
+      if (!(event.target instanceof Node)) return;
+      if (blockListElement.contains(event.target)) return;
+
+      this.hideElement(blockListElement);
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      this.hideElement(blockListElement as HTMLElement);
+    });
+  }
+
+  showBlockListElement(
+    button: HTMLButtonElement,
+    blockListElement: HTMLDivElement,
+  ) {
+    const buttonRect = button.getBoundingClientRect();
+    this.blockListElement.style.top = `${buttonRect.bottom + window.scrollY + 8}px`;
+    this.blockListElement.style.left = `${buttonRect.left + window.scrollX}px`;
+    this.blockListElement.hidden = false;
+    this.blockListElement.setAttribute("aria-hidden", "false");
+  }
+
+  showElement(blockListElement: HTMLElement) {
+    blockListElement.hidden = false;
+    blockListElement.setAttribute("aria-hidden", "false");
   }
 
   updateHighlight() {

--- a/src/content-block/api-client.spec.ts
+++ b/src/content-block/api-client.spec.ts
@@ -1,17 +1,34 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, Mock, test, vi } from "vitest";
 import { APIClient } from "./api-client";
+import type { BlocksResponse } from "./api-client";
 
 interface BlockResponse {
   html: string;
 }
 
-function createSuccessResponse(data: BlockResponse): Response {
+export interface MockResponse {
+  ok: boolean;
+  status: number;
+  text?: Mock<() => Promise<string>>;
+  json?: Mock<() => Promise<BlocksResponse>>;
+}
+
+function createSuccessResponse(data: BlockResponse): MockResponse {
   const text = vi.fn().mockResolvedValue(data.html);
   return {
     ok: true,
     status: 200,
     text,
-  } as unknown as Response;
+  };
+}
+
+function createJsonResponse(data: unknown): MockResponse {
+  const json = vi.fn().mockResolvedValue(data);
+  return {
+    ok: true,
+    status: 200,
+    json,
+  };
 }
 
 function createErrorResponse(status: number): Response {
@@ -126,5 +143,67 @@ describe("APIClient", () => {
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe("fetchAllBlocks", () => {
+    const payload: BlocksResponse = {
+      results: [
+        {
+          title: "Sample Pension Block 1",
+          block_type: "Pension",
+          organisation: {
+            name: "AI Security Institute",
+            content_id: "11111111-2222-3333-4444-000000000000",
+          },
+          state: "published",
+          embed_code: "{{embed:content_block_pension:sample-pension-1}}",
+          formats: [],
+        },
+        {
+          title: "Sample Time Period Block 1",
+          block_type: "Time period",
+          organisation: {
+            name: "AI Security Institute",
+            content_id: "11111111-2222-3333-4444-000000000001",
+          },
+          state: "published",
+          embed_code: "{{embed:content_block_time_period:sample-time-1}}",
+          formats: ["long_form", "years"],
+        },
+      ],
+    };
+
+    test("it fetches from the blocks list URL and unwraps results", async () => {
+      const client = new APIClient(baseUrl);
+
+      fetchMock.mockResolvedValue(createJsonResponse(payload));
+
+      const result = await client.fetchAllBlocks();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/api/blocks`);
+      expect(result).toEqual(payload.results);
+    });
+
+    test("it does not cache results between calls", async () => {
+      const client = new APIClient(baseUrl);
+
+      fetchMock.mockResolvedValue(createJsonResponse(payload));
+
+      await client.fetchAllBlocks();
+      await client.fetchAllBlocks();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("it throws when the response is not ok", async () => {
+      const client = new APIClient(baseUrl);
+
+      fetchMock.mockResolvedValue(createErrorResponse(500));
+
+      await expect(client.fetchAllBlocks()).rejects.toThrow(
+        "Failed to fetch blocks: 500",
+      );
+    });
   });
 });

--- a/src/content-block/api-client.ts
+++ b/src/content-block/api-client.ts
@@ -6,10 +6,37 @@ export interface EmbedCodePreview {
 }
 
 /**
+ * The organisation that owns a content block.
+ */
+export interface ContentBlockOrganisation {
+  name: string;
+  content_id: string;
+}
+
+/**
+ * A single content block as returned by the blocks list endpoint.
+ */
+export interface ContentBlock {
+  title: string;
+  block_type: string; // Maybe an enum in the future
+  organisation: ContentBlockOrganisation;
+  state: string;
+  embed_code: string;
+  formats: string[];
+}
+
+/**
+ * The response shape of the blocks list endpoint.
+ */
+export interface BlocksResponse {
+  results: ContentBlock[];
+}
+
+/**
  * APIClient is a simple client for fetching rendered content blocks from the server.
  *
- * It includes an in-memory cache to avoid redundant network requests for the same embed
- * code. The cache is keyed by the embed code string, and the values are Promises that
+ * It includes an in-memory cache to avoid redundant network requests for the same
+ * embed code. The cache is keyed by the embed code string, and the values are Promises that
  * resolve to the fetched data. This allows multiple concurrent requests for the same
  * embed code to share the same Promise, preventing duplicate fetches.
  */
@@ -19,10 +46,34 @@ import { isValidEmbedCode } from "./regex.ts";
 export class APIClient {
   private cache = new Map<string, Promise<EmbedCodePreview>>();
   private readonly baseUrl: URL;
-  private readonly RENDER_PATH = "/api/blocks/:embedCode/render";
+  private readonly API_BASE_PATH = "/api/blocks";
+  private readonly BLOCKS_PATH = this.API_BASE_PATH;
+  private readonly RENDER_PATH = `${this.API_BASE_PATH}/:embedCode/render`;
 
   constructor(baseUrl: string) {
     this.baseUrl = new URL(baseUrl);
+  }
+
+  /**
+   * Fetches all content blocks from the API.
+   *
+   * Deliberately does not cache the results, as the list of blocks may change over time. Each call to this method will
+   * make a new network request to fetch the latest data.
+   *
+   * @returns A Promise that resolves to an array of ContentBlock objects.
+   */
+  fetchAllBlocks(): Promise<ContentBlock[]> {
+    const url = new URL(this.BLOCKS_PATH, this.baseUrl).toString();
+
+    return fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch blocks: ${response.status}`);
+        }
+
+        return response.json() as Promise<BlocksResponse>;
+      })
+      .then((data) => data.results);
   }
 
   fetchPreview(embedCode: string): Promise<EmbedCodePreview> {


### PR DESCRIPTION
## What & why

Editors previously needed a block's embed code to use it, with no way to discover what exists. This adds an **Insert block** button that opens an overlay listing every available block by title, with its formats nested underneath.

## Changes

- **`APIClient.fetchAllBlocks()`** — fetches `GET /api/blocks` and returns   typed `ContentBlock[]`. Uncached, since the list changes as editors   publish/edit.
- **Insert-block overlay** — a textarea opts in via   `data-cbp-insert-block-button` naming its trigger, so each editor owns  its own overlay. Shows a loading state, then the list (or "Unable to   load blocks." on failure); dismisses on Escape / click-inside /  click-outside, with `role="dialog"` and `aria-hidden`.
- Fetch is deferred to open time and de-duplicated while in flight; DOM is   built via `textContent` so API content can't inject markup. Overlay is  positioned document-relative, accounting for scroll.