### PR TITLE
Cm 993 Insert selected content block embed

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -233,4 +233,52 @@ test.describe("List available blocks", () => {
     await expect(blockList).toHaveAttribute("aria-hidden", "false");
     await expect(blockList).toContainText("Unable to load blocks.");
   });
+
+  test("it inserts the embed code into the textarea and returns focus when a block is clicked", async ({
+    page,
+  }) => {
+    const mockBlocks = {
+      results: [
+        {
+          title: "Pension Block A",
+          block_type: "Pension",
+          organisation: { name: "Test Org", content_id: "test-id-1" },
+          state: "published",
+          embed_code: "{{embed:content_block_pension:abc123}}",
+          formats: [],
+        },
+      ],
+    };
+
+    await page.route(/\/api\/blocks$/, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockBlocks),
+      });
+    });
+
+    const insertButton = page.locator("#insert-content-block-button");
+    const blockList = page.locator(".content-block-highlight__block-list");
+    const textarea = page.locator("textarea.content-block-highlight__input");
+
+    await insertButton.click();
+
+    // Wait for the block list to populate
+    const firstBlockButton = blockList.locator("li button").first();
+    await expect(firstBlockButton).toBeVisible();
+
+    await firstBlockButton.click();
+
+    // Embed code should appear in the textarea
+    await expect(textarea).toHaveValue(
+      "{{embed:content_block_pension:abc123}}",
+    );
+
+    // Block list should be dismissed
+    await expect(blockList).toHaveAttribute("aria-hidden", "true");
+
+    // Focus should have returned to the textarea
+    await expect(textarea).toBeFocused();
+  });
 });

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -140,10 +140,18 @@ test.describe("List available blocks", () => {
     // Check first block (no formats)
     const firstBlock = topLevelList.locator("> li").first();
     await expect(firstBlock).toContainText("Pension Block A");
+    await expect(firstBlock).toHaveAttribute(
+      "data-embed-code",
+      "{{embed:content_block_pension:abc123}}",
+    );
 
     // Check second block (with formats)
     const secondBlock = topLevelList.locator("> li").nth(1);
     await expect(secondBlock).toContainText("Time Period Block B");
+    await expect(secondBlock).toHaveAttribute(
+      "data-embed-code",
+      "{{embed:content_block_time_period:def456}}",
+    );
 
     // Check that formats are displayed as nested list for second block
     const secondBlockFormatsList = secondBlock.locator("ul");
@@ -151,6 +159,14 @@ test.describe("List available blocks", () => {
     await expect(secondBlockFormatsList.locator("li")).toHaveCount(2);
     await expect(secondBlockFormatsList).toContainText("long_form");
     await expect(secondBlockFormatsList).toContainText("years");
+    await expect(secondBlockFormatsList.locator("li").first()).toHaveAttribute(
+      "data-embed-code",
+      "{{embed:content_block_time_period:def456#long_form}}",
+    );
+    await expect(secondBlockFormatsList.locator("li").nth(1)).toHaveAttribute(
+      "data-embed-code",
+      "{{embed:content_block_time_period:def456#years}}",
+    );
   });
 
   test("it hides the block list when clicking outside of it", async ({

--- a/scss/content-block-highlight.scss
+++ b/scss/content-block-highlight.scss
@@ -47,4 +47,30 @@ textarea.content-block-highlight__input {
   border: 1px solid $govuk-border-colour;
   background: $govuk-body-background-colour;
   box-shadow: 0 2px 8px rgb(11 12 12 / 15%);
+
+  button {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: $govuk-link-colour;
+    font-size: inherit;
+    font-family: inherit;
+    text-decoration: underline;
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:focus {
+      outline: 3px solid transparent;
+      color: $govuk-focus-text-colour;
+      background-color: $govuk-focus-colour;
+      box-shadow:
+        0 -2px $govuk-focus-colour,
+        0 4px $govuk-focus-text-colour;
+      text-decoration: none;
+    }
+  }
 }

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -328,15 +328,30 @@ describe("ContentBlockPicker", () => {
       expect(topLevelItems[0].childNodes[0]?.textContent).toBe(
         "Sample Pension Block 1",
       );
+      expect(topLevelItems[0].dataset.embedCode).toBe(
+        "{{embed:content_block_pension:sample-pension-1}}",
+      );
       expect(topLevelItems[0].querySelector("ul")).toBeNull();
       expect(topLevelItems[1].childNodes[0]?.textContent).toBe(
         "Sample Time Period Block 1",
       );
-      expect(
-        Array.from(topLevelItems[1].querySelectorAll("ul > li")).map(
-          (item) => item.textContent,
-        ),
-      ).toEqual(["long_form", "years"]);
+      expect(topLevelItems[1].dataset.embedCode).toBe(
+        "{{embed:content_block_time_period:sample-time-1}}",
+      );
+      const formatItems = Array.from(
+        topLevelItems[1].querySelectorAll("ul > li"),
+      ) as HTMLLIElement[];
+
+      expect(formatItems.map((item) => item.textContent)).toEqual([
+        "long_form",
+        "years",
+      ]);
+      expect(formatItems[0].dataset.embedCode).toBe(
+        "{{embed:content_block_time_period:sample-time-1#long_form}}",
+      );
+      expect(formatItems[1].dataset.embedCode).toBe(
+        "{{embed:content_block_time_period:sample-time-1#years}}",
+      );
     });
 
     test("it positions the block list relative to the document, accounting for scroll", () => {

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -292,7 +292,7 @@ describe("ContentBlockPicker", () => {
       expect(observeSpy).toHaveBeenCalledWith(textarea);
     });
 
-    test("it shows a fetching message and then renders blocks when the configured insert button is clicked", async () => {
+    test("it shows a fetching message when the configured insert button is clicked", async () => {
       const { insertButton, editorInstance } = setupEditorWithInsertButton();
       const fetchAllBlocksMock = vi
         .spyOn(editorInstance.apiClient, "fetchAllBlocks")
@@ -310,6 +310,15 @@ describe("ContentBlockPicker", () => {
       expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
         "false",
       );
+    });
+
+    test("it renders blocks with their formats after fetching", async () => {
+      const { insertButton, editorInstance } = setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      insertButton.click();
 
       await vi.waitFor(() => {
         const topLevelList =
@@ -455,6 +464,165 @@ describe("ContentBlockPicker", () => {
       expect(editorInstance.blockListElement?.getAttribute("aria-hidden")).toBe(
         "true",
       );
+    });
+  });
+
+  describe("insertEmbedCode", () => {
+    test("it inserts the embed code at the caret position", () => {
+      editor.textarea.value = "before after";
+      editor.textarea.selectionStart = 7;
+      editor.textarea.selectionEnd = 7;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe("before {{embed:contact:123}}after");
+    });
+
+    test("it inserts at the beginning when the caret is at position 0", () => {
+      editor.textarea.value = "existing text";
+      editor.textarea.selectionStart = 0;
+      editor.textarea.selectionEnd = 0;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe("{{embed:contact:123}}existing text");
+    });
+
+    test("it replaces selected text with the embed code", () => {
+      editor.textarea.value = "replace me";
+      editor.textarea.selectionStart = 0;
+      editor.textarea.selectionEnd = 10;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe("{{embed:contact:123}}");
+    });
+
+    test("it moves the cursor to after the inserted embed code", () => {
+      editor.textarea.value = "text";
+      editor.textarea.selectionStart = 4;
+      editor.textarea.selectionEnd = 4;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      const expectedPosition = "text{{embed:contact:123}}".length;
+      expect(editor.textarea.selectionStart).toBe(expectedPosition);
+      expect(editor.textarea.selectionEnd).toBe(expectedPosition);
+    });
+
+    test("it dispatches an input event to update the highlight", () => {
+      const inputSpy = vi.fn();
+      editor.textarea.addEventListener("input", inputSpy);
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("block list item clicks", () => {
+    test("it inserts the embed code and closes the list when a block item button is clicked", async () => {
+      const { insertButton, editorInstance, textareaWithButton } =
+        setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      insertButton.click();
+
+      await vi.waitFor(() => {
+        expect(
+          editorInstance.blockListElement?.querySelector("ul"),
+        ).not.toBeNull();
+      });
+
+      const firstBlockButton = editorInstance.blockListElement?.querySelector(
+        "li button",
+      ) as HTMLButtonElement;
+      firstBlockButton.click();
+
+      expect(textareaWithButton.value).toBe(
+        "{{embed:content_block_pension:sample-pension-1}}",
+      );
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+    });
+
+    test("it inserts the format embed code when a format item button is clicked", async () => {
+      const { insertButton, editorInstance, textareaWithButton } =
+        setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      insertButton.click();
+
+      await vi.waitFor(() => {
+        expect(
+          editorInstance.blockListElement?.querySelector("ul"),
+        ).not.toBeNull();
+      });
+
+      const formatButton = editorInstance.blockListElement?.querySelector(
+        "li ul li button",
+      ) as HTMLButtonElement;
+      formatButton.click();
+
+      expect(textareaWithButton.value).toBe(
+        "{{embed:content_block_time_period:sample-time-1#long_form}}",
+      );
+      expect(editorInstance.blockListElement?.hidden).toBe(true);
+    });
+
+    test("it inserts at the current caret position in the textarea", async () => {
+      const { insertButton, editorInstance, textareaWithButton } =
+        setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      textareaWithButton.value = "start end";
+      textareaWithButton.selectionStart = 6;
+      textareaWithButton.selectionEnd = 6;
+
+      insertButton.click();
+
+      await vi.waitFor(() => {
+        expect(
+          editorInstance.blockListElement?.querySelector("ul"),
+        ).not.toBeNull();
+      });
+
+      const firstBlockButton = editorInstance.blockListElement?.querySelector(
+        "li button",
+      ) as HTMLButtonElement;
+      firstBlockButton.click();
+
+      expect(textareaWithButton.value).toBe(
+        "start {{embed:content_block_pension:sample-pension-1}}end",
+      );
+    });
+
+    test("it returns focus to the textarea after inserting a block", async () => {
+      const { insertButton, editorInstance, textareaWithButton } =
+        setupEditorWithInsertButton();
+      vi.spyOn(editorInstance.apiClient, "fetchAllBlocks").mockResolvedValue(
+        sampleBlocks,
+      );
+
+      insertButton.click();
+
+      await vi.waitFor(() => {
+        expect(
+          editorInstance.blockListElement?.querySelector("ul"),
+        ).not.toBeNull();
+      });
+
+      const firstBlockButton = editorInstance.blockListElement?.querySelector(
+        "li button",
+      ) as HTMLButtonElement;
+      firstBlockButton.click();
+
+      expect(document.activeElement).toBe(textareaWithButton);
     });
   });
 

--- a/src/content-block-editor.spec.ts
+++ b/src/content-block-editor.spec.ts
@@ -518,6 +518,152 @@ describe("ContentBlockPicker", () => {
 
       expect(inputSpy).toHaveBeenCalledTimes(1);
     });
+
+    test("it inserts after the closing braces if the caret is inside an embed code", () => {
+      editor.textarea.value = "text {{embed:contact:existing}} more text";
+      // Position caret inside the embed code (at the 'e' in 'existing')
+      editor.textarea.selectionStart = 20;
+      editor.textarea.selectionEnd = 20;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe(
+        "text {{embed:contact:existing}}{{embed:contact:123}} more text",
+      );
+    });
+
+    test("it inserts after the embed code even when caret is at the start", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} more text";
+      // Position caret at the start of the embed code
+      editor.textarea.selectionStart = 7;
+      editor.textarea.selectionEnd = 7;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:123}} more text",
+      );
+    });
+
+    test("it does not duplicate text when selected range is inside an embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} more text";
+      // Selection is entirely inside the embed code.
+      editor.textarea.selectionStart = 15;
+      editor.textarea.selectionEnd = 20;
+
+      editor.insertEmbedCode("{{embed:contact:123}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:123}} more text",
+      );
+    });
+  });
+
+  describe("adjustInsertPositionIfSelectionOverlapsEmbedCode", () => {
+    test("it inserts after the embed code when selection starts before and ends inside", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select from "before " to middle of embed code
+      editor.textarea.selectionStart = 0;
+      editor.textarea.selectionEnd = 20;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:new}} after",
+      );
+    });
+
+    test("it inserts after the embed code when selection starts inside and ends after", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select from middle of embed code to " after"
+      editor.textarea.selectionStart = 20;
+      editor.textarea.selectionEnd = 43;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:new}}",
+      );
+    });
+
+    test("it inserts after the embed code when selection fully contains an embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select entire line including the embed code
+      editor.textarea.selectionStart = 0;
+      editor.textarea.selectionEnd = 43;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:new}}",
+      );
+    });
+
+    test("it inserts after the rightmost embed code when selection overlaps multiple embed codes", () => {
+      editor.textarea.value =
+        "text {{embed:contact:first}} middle {{embed:contact:second}} end";
+      // Select from start of first embed to middle of second embed
+      editor.textarea.selectionStart = 5;
+      editor.textarea.selectionEnd = 50;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "text {{embed:contact:first}} middle {{embed:contact:second}}{{embed:contact:new}} end",
+      );
+    });
+
+    test("it preserves normal behavior when selection does not overlap with any embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select "after"
+      editor.textarea.selectionStart = 34;
+      editor.textarea.selectionEnd = 39;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}} {{embed:contact:new}}",
+      );
+    });
+
+    test("it handles selection at the exact boundary of an embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select from the opening braces to the closing braces (entire embed code)
+      editor.textarea.selectionStart = 7;
+      editor.textarea.selectionEnd = 33;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:new}} after",
+      );
+    });
+
+    test("it handles selection that touches but does not overlap the start of an embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select "before " (ends right before the embed code)
+      editor.textarea.selectionStart = 0;
+      editor.textarea.selectionEnd = 7;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "{{embed:contact:new}}{{embed:contact:existing}} after",
+      );
+    });
+
+    test("it handles selection that touches but does not overlap the end of an embed code", () => {
+      editor.textarea.value = "before {{embed:contact:existing}} after";
+      // Select " after" (starts right after the embed code)
+      editor.textarea.selectionStart = 33;
+      editor.textarea.selectionEnd = 39;
+
+      editor.insertEmbedCode("{{embed:contact:new}}");
+
+      expect(editor.textarea.value).toBe(
+        "before {{embed:contact:existing}}{{embed:contact:new}}",
+      );
+    });
   });
 
   describe("block list item clicks", () => {

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -188,18 +188,64 @@ export class ContentBlockEditor {
   }
 
   insertEmbedCode(embedCode: string) {
-    const start = this.textarea.selectionStart ?? 0;
-    const end = this.textarea.selectionEnd ?? 0;
+    const selectionStart = this.textarea.selectionStart ?? 0;
+    const selectionEnd = this.textarea.selectionEnd ?? 0;
     const currentValue = this.textarea.value;
 
-    this.textarea.value =
-      currentValue.slice(0, start) + embedCode + currentValue.slice(end);
+    const { insertPosition, textEndPosition } =
+      this.adjustInsertPositionIfSelectionOverlapsEmbedCode(
+        selectionStart,
+        selectionEnd,
+        currentValue,
+      );
 
-    const newCursorPosition = start + embedCode.length;
+    this.textarea.value =
+      currentValue.slice(0, insertPosition) +
+      embedCode +
+      currentValue.slice(textEndPosition);
+
+    const newCursorPosition = insertPosition + embedCode.length;
     this.textarea.selectionStart = newCursorPosition;
     this.textarea.selectionEnd = newCursorPosition;
 
     this.textarea.dispatchEvent(new Event("input"));
+  }
+
+  private adjustInsertPositionIfSelectionOverlapsEmbedCode(
+    selectionStart: number,
+    selectionEnd: number,
+    currentValue: string,
+  ): { insertPosition: number; textEndPosition: number } {
+    const embedCodeMatches = currentValue.matchAll(embedRegex);
+    let rightmostOverlapEnd = -1;
+
+    for (const match of embedCodeMatches) {
+      const matchStart = match.index!;
+      const matchEnd = match.index! + match[0].length;
+
+      // Check if selection overlaps with this embed code
+      const startOverlaps =
+        selectionStart >= matchStart && selectionStart < matchEnd;
+      const endOverlaps = selectionEnd > matchStart && selectionEnd <= matchEnd;
+      const fullyContains =
+        selectionStart < matchStart && selectionEnd > matchEnd;
+
+      if (startOverlaps || endOverlaps || fullyContains) {
+        rightmostOverlapEnd = Math.max(rightmostOverlapEnd, matchEnd);
+      }
+    }
+
+    if (rightmostOverlapEnd !== -1) {
+      return {
+        insertPosition: rightmostOverlapEnd,
+        textEndPosition: Math.max(selectionEnd, rightmostOverlapEnd),
+      };
+    }
+
+    return {
+      insertPosition: selectionStart,
+      textEndPosition: selectionEnd,
+    };
   }
 
   private createBlockListButton(

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -187,6 +187,35 @@ export class ContentBlockEditor {
     );
   }
 
+  insertEmbedCode(embedCode: string) {
+    const start = this.textarea.selectionStart ?? 0;
+    const end = this.textarea.selectionEnd ?? 0;
+    const currentValue = this.textarea.value;
+
+    this.textarea.value =
+      currentValue.slice(0, start) + embedCode + currentValue.slice(end);
+
+    const newCursorPosition = start + embedCode.length;
+    this.textarea.selectionStart = newCursorPosition;
+    this.textarea.selectionEnd = newCursorPosition;
+
+    this.textarea.dispatchEvent(new Event("input"));
+  }
+
+  private createBlockListButton(
+    label: string,
+    embedCode: string,
+  ): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.addEventListener("click", () => {
+      this.insertEmbedCode(embedCode);
+      this.textarea.focus();
+    });
+    return button;
+  }
+
   private renderBlockList(blocks: ContentBlock[]) {
     if (!this.blockListElement) return;
 
@@ -194,16 +223,21 @@ export class ContentBlockEditor {
 
     for (const block of blocks) {
       const blockItem = document.createElement("li");
-      blockItem.append(document.createTextNode(block.title));
       blockItem.dataset.embedCode = block.embed_code;
+      blockItem.appendChild(
+        this.createBlockListButton(block.title, block.embed_code),
+      );
 
       if (block.formats.length > 0) {
         const formatsList = document.createElement("ul");
 
         for (const format of block.formats) {
+          const formatEmbedCode = `${block.embed_code.slice(0, -2)}#${format}}}`;
           const formatItem = document.createElement("li");
-          formatItem.dataset.embedCode = `${block.embed_code.slice(0, -2)}#${format}}}`;
-          formatItem.textContent = format;
+          formatItem.dataset.embedCode = formatEmbedCode;
+          formatItem.appendChild(
+            this.createBlockListButton(format, formatEmbedCode),
+          );
           formatsList.appendChild(formatItem);
         }
 

--- a/src/content-block-editor.ts
+++ b/src/content-block-editor.ts
@@ -195,12 +195,14 @@ export class ContentBlockEditor {
     for (const block of blocks) {
       const blockItem = document.createElement("li");
       blockItem.append(document.createTextNode(block.title));
+      blockItem.dataset.embedCode = block.embed_code;
 
       if (block.formats.length > 0) {
         const formatsList = document.createElement("ul");
 
         for (const format of block.formats) {
           const formatItem = document.createElement("li");
+          formatItem.dataset.embedCode = `${block.embed_code.slice(0, -2)}#${format}}}`;
           formatItem.textContent = format;
           formatsList.appendChild(formatItem);
         }


### PR DESCRIPTION
This PR makes block list entries actionable, so selecting a block (or format) inserts its embed code into the editor textarea.

It makes the block list actionable and inserts the embed code directly.

A lot of this PR deals with the edge cases where the caret is inside or touching an existing embed code. There should be some more work on these when we get user testing.