### PR TITLE
Cr 55 add a filter to remove e 2 e tests in block list

### DIFF
--- a/e2e/picker.spec.ts
+++ b/e2e/picker.spec.ts
@@ -99,7 +99,7 @@ test.describe("List available blocks", () => {
         },
         {
           title: "Time Period Block B",
-          block_type: "Time period",
+          block_type: "Time Period",
           organisation: {
             name: "Test Org",
             content_id: "test-id-2",

--- a/src/content-block-picker.spec.ts
+++ b/src/content-block-picker.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe, beforeEach, vi } from "vitest";
 import { ContentBlockPicker } from "./content-block-picker.ts";
-import type { ContentBlock } from "./content-block/api-client.ts";
+import { BlockType, type ContentBlock } from "./content-block/api-client.ts";
 
 describe("ContentBlockPicker", () => {
   let textarea: HTMLTextAreaElement;
@@ -11,7 +11,7 @@ describe("ContentBlockPicker", () => {
   const sampleBlocks: ContentBlock[] = [
     {
       title: "Sample Pension Block 1",
-      block_type: "Pension",
+      block_type: BlockType.Pension,
       organisation: {
         name: "AI Security Institute",
         content_id: "11111111-2222-3333-4444-000000000000",
@@ -22,7 +22,7 @@ describe("ContentBlockPicker", () => {
     },
     {
       title: "Sample Time Period Block 1",
-      block_type: "Time period",
+      block_type: BlockType.TimePeriod,
       organisation: {
         name: "AI Security Institute",
         content_id: "11111111-2222-3333-4444-000000000001",

--- a/src/content-block/api-client.spec.ts
+++ b/src/content-block/api-client.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, Mock, test, vi } from "vitest";
-import { APIClient } from "./api-client";
-import type { BlocksResponse } from "./api-client";
+import { APIClient, BlockType, type BlocksResponse } from "./api-client";
 
 interface BlockResponse {
   html: string;
@@ -150,7 +149,7 @@ describe("APIClient", () => {
       results: [
         {
           title: "Sample Pension Block 1",
-          block_type: "Pension",
+          block_type: BlockType.Pension,
           organisation: {
             name: "AI Security Institute",
             content_id: "11111111-2222-3333-4444-000000000000",
@@ -161,7 +160,7 @@ describe("APIClient", () => {
         },
         {
           title: "Sample Time Period Block 1",
-          block_type: "Time period",
+          block_type: BlockType.TimePeriod,
           organisation: {
             name: "AI Security Institute",
             content_id: "11111111-2222-3333-4444-000000000001",
@@ -204,6 +203,39 @@ describe("APIClient", () => {
       await expect(client.fetchAllBlocks()).rejects.toThrow(
         "Failed to fetch blocks: 500",
       );
+    });
+
+    test("it skips unsupported block types and warns", async () => {
+      const client = new APIClient(baseUrl);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const payloadWithUnsupportedType: BlocksResponse = {
+        results: [
+          ...payload.results,
+          {
+            title: "Unsupported Block",
+            block_type: "Unknown" as BlockType,
+            organisation: {
+              name: "AI Security Institute",
+              content_id: "11111111-2222-3333-4444-000000000999",
+            },
+            state: "published",
+            embed_code: "{{embed:content_block_unknown:sample-unknown-1}}",
+            formats: [],
+          },
+        ],
+      };
+
+      fetchMock.mockResolvedValue(
+        createJsonResponse(payloadWithUnsupportedType),
+      );
+
+      const result = await client.fetchAllBlocks();
+
+      expect(result).toEqual(payload.results);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Skipping unsupported block type "Unknown" for block "Unsupported Block".',
+      );
+      warnSpy.mockRestore();
     });
   });
 });

--- a/src/content-block/api-client.spec.ts
+++ b/src/content-block/api-client.spec.ts
@@ -237,5 +237,31 @@ describe("APIClient", () => {
       );
       warnSpy.mockRestore();
     });
+
+    test('it skips blocks with titles that start with "E2E Test"', async () => {
+      const client = new APIClient(baseUrl);
+      const payloadWithE2ETestTitle: BlocksResponse = {
+        results: [
+          ...payload.results,
+          {
+            title: "E2E Test Pension Block",
+            block_type: BlockType.Pension,
+            organisation: {
+              name: "AI Security Institute",
+              content_id: "11111111-2222-3333-4444-000000000998",
+            },
+            state: "published",
+            embed_code: "{{embed:content_block_pension:e2e-test-pension-1}}",
+            formats: [],
+          },
+        ],
+      };
+
+      fetchMock.mockResolvedValue(createJsonResponse(payloadWithE2ETestTitle));
+
+      const result = await client.fetchAllBlocks();
+
+      expect(result).toEqual(payload.results);
+    });
   });
 });

--- a/src/content-block/api-client.ts
+++ b/src/content-block/api-client.ts
@@ -5,6 +5,12 @@ export interface EmbedCodePreview {
   html: string;
 }
 
+export enum BlockType {
+  Pension = "Pension",
+  Contact = "Contact",
+  TimePeriod = "Time Period",
+}
+
 /**
  * The organisation that owns a content block.
  */
@@ -18,7 +24,7 @@ export interface ContentBlockOrganisation {
  */
 export interface ContentBlock {
   title: string;
-  block_type: string; // Maybe an enum in the future
+  block_type: BlockType;
   organisation: ContentBlockOrganisation;
   state: string;
   embed_code: string;
@@ -42,6 +48,25 @@ export interface BlocksResponse {
  */
 
 import { isValidEmbedCode } from "./regex.ts";
+
+const supportedBlockTypes = new Set<string>(Object.values(BlockType));
+
+function isSupportedBlockType(blockType: string): blockType is BlockType {
+  return supportedBlockTypes.has(blockType);
+}
+
+function isSupportedContentBlock(
+  block: ContentBlockApiResponse,
+): block is ContentBlock {
+  if (isSupportedBlockType(block.block_type)) {
+    return true;
+  }
+
+  console.warn(
+    `Skipping unsupported block type "${block.block_type}" for block "${block.title}".`,
+  );
+  return false;
+}
 
 export class APIClient {
   private cache = new Map<string, Promise<EmbedCodePreview>>();
@@ -73,7 +98,7 @@ export class APIClient {
 
         return response.json() as Promise<BlocksResponse>;
       })
-      .then((data) => data.results);
+      .then((data) => data.results.filter(isSupportedContentBlock));
   }
 
   fetchPreview(embedCode: string): Promise<EmbedCodePreview> {

--- a/src/content-block/api-client.ts
+++ b/src/content-block/api-client.ts
@@ -50,14 +50,17 @@ export interface BlocksResponse {
 import { isValidEmbedCode } from "./regex.ts";
 
 const supportedBlockTypes = new Set<string>(Object.values(BlockType));
+const EXCLUDED_TITLE_PREFIX = "E2E";
 
 function isSupportedBlockType(blockType: string): blockType is BlockType {
   return supportedBlockTypes.has(blockType);
 }
 
-function isSupportedContentBlock(
-  block: ContentBlockApiResponse,
-): block is ContentBlock {
+function isSupportedContentBlock(block: ContentBlock): boolean {
+  if (block.title.startsWith(EXCLUDED_TITLE_PREFIX)) {
+    return false;
+  }
+
   if (isSupportedBlockType(block.block_type)) {
     return true;
   }


### PR DESCRIPTION
Originally I did all this in the CBM but we decided that tax blocks should be moved to here. As I was updating the swagger api tests for the exclude test user blocks it became evident that we couldn't use the same mechanism to block e2e test blocks.

The API client doesn't send any auth or bearer token. This was a deliberate decision during development, but tht stop us using e2e user as the switch. To fix this we've added a type white list and and a text title exclusion here.