### PR TITLE
(CR-45) Introduce GH action to publish to NPM

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,28 @@
+name: "[Release] Publish package to npm"
+
+on: workflow_dispatch
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-24.04
+    environment: production
+    permissions:
+      id-token: write # required for Trusted publishing (https://docs.npmjs.com/trusted-publishers)
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .node-version
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false # never use caching in release builds
+
+      - run: npm ci
+
+      - run: npm run test
+
+      - run: npm run build
+
+      - run: npm publish

--- a/README.md
+++ b/README.md
@@ -86,3 +86,19 @@ You can see a [demo of the work so far here](https://alphagov.github.io/content-
 ## Future work
 
 In future, we'd like to provide previews of the content blocks when the user hovers over an embed code.
+
+## Release Process
+
+This package is published to npm at https://www.npmjs.com/package/content-block-picker. In order to trigger a new release we simply need to:
+
+1. Bump the version number in the package.json file.
+
+   This can be done with the `npm version` command, e.g. `npm version minor` or `npm version 2.1.3`.
+
+2. Commit and merge this change to main.
+
+   Observing the usual PR process.
+
+3. Run the 'Publish to NPM' action in GitHub Actions.
+
+   Navigate to https://github.com/alphagov/content-block-picker/actions/workflows/publish-to-npm.yml and run a new workflow.


### PR DESCRIPTION
This makes use of NPM's 'Trusted Publishing' feature, by which we can specify this particular workflow action as a trusted source of publishing. See https://docs.npmjs.com/trusted-publishers for more information. The configuration steps in NPM have been undertaken and this particular org repo and action combination are now a trusted source.

The configuration which has been undertaken in npmjs.com involves
setting the combination of the following used in the publishing
process:
- organisation
- repository
- workflow file

Once these are set, NPM will now trust that publish requests from this
organisation, in this repo, and specifically from the
publish-to-npm.yml file will all be allowed to succeed.

The way this works is as follows:

- The publish-to-npm workflow is triggered in GH Actions.
- In this job, the workflow requests an OIDC token from Github itself
  directly. This token contains the 3 pieces of information from
  above (org, repo, filename).
- This workflow then exchanges this token with NPM for a valid NPM
  token to use in this workflow. The way this works is:
    - The token itself is a signed JWT.
    - The token is signed using GitHub's private key.
    - NPM will verify the token using GitHub's public key, to confirm
      the token is authentic.
    - The token claims contain the values relating to the org, repo
      and workflow file.
    - NPM reads these claims and authorizes the request.

---

Also adds brief release process instructions to the README.md. This, however, is subject to change as we work out what our team processes should be.