### PR TITLE
(CR-120) Add a build step to CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+
+on: workflow_call
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".node-version"
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
   prettier:
     uses: ./.github/workflows/prettier.yml
 
+  build:
+    uses: ./.github/workflows/build.yml
+
   run-playwright-tests:
     name: Playwright
     needs:


### PR DESCRIPTION
Introduce a build workflow which runs as part of the usual CI run.

Prior to this we were not running the build as part of the usual PR process. This means that any failing syntax or type errors would not be caught until the code was merged to `main`.

This CI workflow runs on all PRs so we should be able to catch failures sooner.

