### PR TITLE
Release v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "content-block-picker",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "content-block-picker",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "dompurify": "^3.4.13",
         "govuk-frontend": "^6.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content-block-picker",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "main": "./dist/content-block-picker.umd.js",
   "module": "./dist/content-block-picker.esm.js",
   "scripts": {


### PR DESCRIPTION
Release latest changes. Includes
- small dependabot fixes
- the rename of the built JS files
- the removal of the dist dir

Technically this could be a major version bump as the built file names are changing and this could be breaking but as it's the first version we'll be using from NPM directly (instead of through git) I think it's fine.

Following the [Release Process instructions](https://github.com/alphagov/content-block-picker#release-process), once this PR is merged I'll manually trigger the publishing of the new version