### PR TITLE
(CR-45) Include repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
   "dependencies": {
     "dompurify": "^3.4.13",
     "govuk-frontend": "^6.4.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alphagov/content-block-picker"
   }
 }


### PR DESCRIPTION
NPM expects this information to be set when publishing packages using Trusted Publishing  so that it can verify the information against the OIDC claim.