### PR TITLE
(CR-45) Remove old release job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,3 @@ jobs:
       - lint
       - prettier
     uses: ./.github/workflows/vitest.yml
-
-  release:
-    needs:
-      - vitest
-      - run-playwright-tests
-    permissions:
-      contents: write
-    uses: alphagov/govuk-infrastructure/.github/workflows/publish-npm-package.yml@main
-    with:
-      deploy_to_github_pages: true
-    secrets:
-      NODE_AUTH_TOKEN: ${{ secrets.ALPHAGOV_NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
This is still attempting (and failing) to run on merges to main and is safe to remove now that we have a new way of publishing.